### PR TITLE
return property title in header, association data output

### DIFF
--- a/src/main/java/com/openlattice/chronicle/constants/OutputConstants.java
+++ b/src/main/java/com/openlattice/chronicle/constants/OutputConstants.java
@@ -6,7 +6,7 @@ public class OutputConstants {
     }
 
     // prefix for column names
-    public static final String ENTITY_PREFIX = "app_";
-    public static final String ASSOCIATION_PREFIX = "user_";
+    public static final String APP_PREFIX = "app_";
+    public static final String USER_PREFIX = "user_";
 
 }

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1065,10 +1065,10 @@ public class ChronicleServiceImpl implements ChronicleService {
                         Map<String, Set<Object>> neighborDetails = Maps.newHashMap();
                         neighbor.getNeighborDetails().get()
                                 .forEach( ( key, value ) -> neighborDetails.put(
-                                        ENTITY_PREFIX + columnNameDictionary.get( key.toString()), value ) );
+                                        APP_PREFIX + columnNameDictionary.get( key.toString()), value ) );
                         neighbor.getAssociationDetails()
                                 .forEach( ( key, value ) -> neighborDetails.put(
-                                        ASSOCIATION_PREFIX + columnNameDictionary.get(key.toString()), value ) );
+                                        USER_PREFIX + columnNameDictionary.get(key.toString()), value ) );
 
                         return neighborDetails;
                     } )


### PR DESCRIPTION
With this, the column headers are much clearer, and we have a way to change the column names.

Also includes adding association data into the exported data.

![image](https://user-images.githubusercontent.com/7630327/82000039-fa844300-960b-11ea-8a09-2ad1e7cfe4ab.png)
