### PR TITLE
add new endpoint for app usage, add edgeId as input of helper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ configurations {
 }
 
 ext.odata_version = '4.2.0'
-ext.chronicle_api_version = '0.0.9-SNAPSHOT'
+ext.chronicle_api_version = '0.0.10-SNAPSHOT'
 dependencies {
     compile "com.google.guava:guava:${guava_version}"
 

--- a/src/main/java/com/openlattice/chronicle/controllers/ChronicleStudyController.java
+++ b/src/main/java/com/openlattice/chronicle/controllers/ChronicleStudyController.java
@@ -245,6 +245,41 @@ public class ChronicleStudyController implements ChronicleStudyApi {
         throw new InsufficientAuthenticationException( "request is not authenticated" );
     }
 
+    @RequestMapping(
+            path = PARTICIPANT_PATH + DATA_PATH + STUDY_ID_PATH + ENTITY_KEY_ID_PATH + USAGE_PATH,
+            method = RequestMethod.GET,
+            produces = { MediaType.APPLICATION_JSON_VALUE, CustomMediaType.TEXT_CSV_VALUE }
+    )
+    public Iterable<Map<String, Set<Object>>> getAllParticipantAppsUsageData(
+            @PathVariable( STUDY_ID ) UUID studyId,
+            @PathVariable( ENTITY_KEY_ID ) UUID participantEntityKeyId,
+            @RequestParam( value = FILE_TYPE, required = false ) FileType fileType,
+            HttpServletResponse response ) {
+
+        Iterable<Map<String, Set<Object>>> data = getAllParticipantAppsUsageData( studyId,
+                participantEntityKeyId,
+                fileType );
+
+        String fileName = getParticipantDataFileName( "ChronicleAppUsageData_", studyId, participantEntityKeyId );
+        setContentDisposition( response, fileName, fileType );
+        setDownloadContentType( response, fileType );
+        return data;
+    }
+
+    public Iterable<Map<String, Set<Object>>> getAllParticipantAppsUsageData(
+            UUID studyId,
+            UUID participantEntityKeyId,
+            FileType fileType ) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if ( authentication instanceof JwtAuthentication ) {
+            String token = ( (JwtAuthentication) authentication ).getToken();
+            return chronicleService.getAllParticipantAppsUsageData( studyId, participantEntityKeyId, token );
+        }
+
+        throw new InsufficientAuthenticationException( "request is not authenticated" );
+    }
+
     private String getParticipantDataFileName( String fileNamePrefix, UUID studyId, UUID participantEntityKeyId ) {
         String participantId = chronicleService
                 .getParticipantEntity( studyId, participantEntityKeyId )

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleService.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleService.java
@@ -62,6 +62,11 @@ public interface ChronicleService {
             UUID participantEntityId,
             String token );
 
+    Iterable<Map<String, Set<Object>>> getAllParticipantAppsUsageData(
+            UUID studyId,
+            UUID participantEntityId,
+            String token );
+
     Map<FullQualifiedName, Set<Object>> getParticipantEntity( UUID studyId, UUID participantEntityId );
 
     ParticipationStatus getParticipationStatus( UUID studyId, String participantId );

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1088,7 +1088,7 @@ public class ChronicleServiceImpl implements ChronicleService {
             UUID studyId,
             UUID participantEntityKeyId,
             String token ) {
-        return getParticipantDataHelper( studyId, participantEntityKeyId, recordedByESID,CHRONICLE_USER_APPS, token );
+        return getParticipantDataHelper( studyId, participantEntityKeyId, usedByESID, CHRONICLE_USER_APPS, token );
     }
 
 

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1018,6 +1018,7 @@ public class ChronicleServiceImpl implements ChronicleService {
     private Iterable<Map<String, Set<Object>>> getParticipantDataHelper(
             UUID studyId,
             UUID participantEntityKeyId,
+            UUID edgeEntitySetId,
             String entitySetName,
             String token ) {
         try {
@@ -1037,7 +1038,7 @@ public class ChronicleServiceImpl implements ChronicleService {
                             Set.of( participantEntityKeyId ),
                             java.util.Optional.of( ImmutableSet.of( srcEntitySetId ) ),
                             java.util.Optional.of( ImmutableSet.of( participantEntitySetId ) ),
-                            java.util.Optional.of( ImmutableSet.of( recordedByESID ) )
+                            java.util.Optional.of( ImmutableSet.of( edgeEntitySetId ) )
                     )
 
             );
@@ -1071,7 +1072,7 @@ public class ChronicleServiceImpl implements ChronicleService {
             UUID studyId,
             UUID participatedInEntityKeyId,
             String token ) {
-        return getParticipantDataHelper( studyId, participatedInEntityKeyId, PREPROCESSED_DATA_ENTITY_SET_NAME, token );
+        return getParticipantDataHelper( studyId, participatedInEntityKeyId, recordedByESID, PREPROCESSED_DATA_ENTITY_SET_NAME, token );
     }
 
     @Override
@@ -1079,8 +1080,17 @@ public class ChronicleServiceImpl implements ChronicleService {
             UUID studyId,
             UUID participantEntityKeyId,
             String token ) {
-        return getParticipantDataHelper( studyId, participantEntityKeyId, DATA_ENTITY_SET_NAME, token );
+        return getParticipantDataHelper( studyId, participantEntityKeyId, recordedByESID, DATA_ENTITY_SET_NAME, token );
     }
+
+    @Override
+    public Iterable<Map<String, Set<Object>>> getAllParticipantAppsUsageData(
+            UUID studyId,
+            UUID participantEntityKeyId,
+            String token ) {
+        return getParticipantDataHelper( studyId, participantEntityKeyId, recordedByESID,CHRONICLE_USER_APPS, token );
+    }
+
 
     @Override
     @Nonnull


### PR DESCRIPTION
This PR implements a new endpoint to get AppsUsage data.

This requires an additional argument in getParticipantDataHelper, because of the different associationType for the AppsUsage data.