### PR TITLE
Bugfix/timezone

### DIFF
--- a/src/main/java/com/openlattice/chronicle/constants/EdmConstants.java
+++ b/src/main/java/com/openlattice/chronicle/constants/EdmConstants.java
@@ -46,5 +46,6 @@ public class EdmConstants {
     public static final FullQualifiedName DURATION        = new FullQualifiedName( "general.Duration" );
     public static final FullQualifiedName OL_ID_FQN       = new FullQualifiedName( "ol.id" );
     public static final FullQualifiedName USER_FQN        = new FullQualifiedName( "ol.user" );
+    public static final FullQualifiedName TIMEZONE_FQN    = new FullQualifiedName( "ol.timezone" );
 
 }

--- a/src/main/java/com/openlattice/chronicle/constants/OutputConstants.java
+++ b/src/main/java/com/openlattice/chronicle/constants/OutputConstants.java
@@ -8,5 +8,6 @@ public class OutputConstants {
     // prefix for column names
     public static final String APP_PREFIX = "app_";
     public static final String USER_PREFIX = "user_";
+    public static final String DEFAULT_TIMEZONE = "UTC";
 
 }


### PR DESCRIPTION
This:
- get a Map<fqn_string, PropertyType>, where the propertyType information is based on entitySetPropertyMetadata.  That way all information is present for the rest.
- hide the primary key columns.  Those don't contain useful data.
- transform datetimes with the correct timezone