### PR TITLE
Fix/avoid creating existing entities

### DIFF
--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1152,7 +1152,7 @@ public class ChronicleServiceImpl implements ChronicleService {
 
     @Scheduled (fixedRate = 60000)
     public void refreshUserAppsEntityIds() {
-        logger.info( "refreshing chronicle_user_apps entity ids" );
+        logger.info( "refreshing chronicle_user_apps entity key ids" );
 
         try {
             ApiClient apiClient = prodApiClientCache.get( ApiClient.class );
@@ -1170,9 +1170,9 @@ public class ChronicleServiceImpl implements ChronicleService {
 
             userAppsEntityKeyIds.addAll( entityIds );
 
-            logger.info( "loaded {} entity ids from chronicle_user_apps", entityIds.size() );
+            logger.info( "loaded {} entity key ids from chronicle_user_apps", entityIds.size() );
         } catch ( Exception e ) {
-            logger.error( "error loading entity ids from chronicle_user_apps" );
+            logger.error( "error loading entity key ids from chronicle_user_apps" );
         }
 
     }

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1165,7 +1165,7 @@ public class ChronicleServiceImpl implements ChronicleService {
 
             // get entity key ids
             Set<UUID> entityIds = StreamUtil.stream( data )
-                    .map( entry -> UUID.fromString(  entry.get( ID_FQN ).iterator().next().toString() ))
+                    .map( entry -> UUID.fromString( entry.get( ID_FQN ).iterator().next().toString() ) )
                     .collect( Collectors.toSet() );
 
             userAppsEntityKeyIds.addAll( entityIds );

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1150,7 +1150,7 @@ public class ChronicleServiceImpl implements ChronicleService {
         return result;
     }
 
-    @Scheduled (fixedRate = 6000)
+    @Scheduled (fixedRate = 60000)
     public void refreshUserAppsEntityIds() {
         logger.info( "refreshing chronicle_user_apps entity ids" );
 
@@ -1169,7 +1169,7 @@ public class ChronicleServiceImpl implements ChronicleService {
                     .collect( Collectors.toSet() );
 
             userAppsEntityKeyIds.addAll( entityIds );
-            
+
             logger.info( "loaded {} entity ids from chronicle_user_apps", entityIds.size() );
         } catch ( Exception e ) {
             logger.error( "error loading entity ids from chronicle_user_apps" );


### PR DESCRIPTION
PR:

- Load entity key ids from chronicle_user_apps every minute
- When logging data, use IntegrationApi to get entity key id of a given entity
- Only if the entity key id doesn't exist in memory, create a new entity