### PR TITLE
exit early from getQuestionnaires 

### DIFF
--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1763,7 +1763,7 @@ public class ChronicleServiceImpl implements ChronicleService {
                         studyId,
                         CHRONICLE_SURVEYS.toString(),
                         organizationId );
-                return null;
+                return ImmutableMap.of();
             }
 
             // check if study is valid

--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -1757,6 +1757,15 @@ public class ChronicleServiceImpl implements ChronicleService {
         try {
             logger.info( "Retrieving questionnaires for study :{}", studyId );
 
+            // If an organization does not have the chronicle_surveys app installed, exit early
+            if ( !entitySetIdsByOrgId.get( CHRONICLE_SURVEYS ).containsKey( organizationId ) ) {
+                logger.warn( "No questionnaires found for study {}. {} is not installed on organization with id {}. ",
+                        studyId,
+                        CHRONICLE_SURVEYS.toString(),
+                        organizationId );
+                return null;
+            }
+
             // check if study is valid
             UUID studyEntityKeyId = Preconditions
                     .checkNotNull( getStudyEntityKeyId( organizationId, studyId ), "invalid studyId: " + studyId );


### PR DESCRIPTION
PR:
The `getQuestionnaires` endpoint is called every 15 minute by android devices. It returns questionnaires available for a given study in an organization. The android device then sends a push notification, prompting the user to click to be redirected to a web page where they can fill out the questionnaire. This is only possible if an organization has the `chronicle_surveys` app installed.

This PR checks if an organization has `chronicle_survey` installed and returns a null value instead of throwing an exception resulting from trying to access non-existent entity set ids. 