### PR TITLE
Task/cache user app fullnames

### DIFF
--- a/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
+++ b/src/main/java/com/openlattice/chronicle/services/ChronicleServiceImpl.java
@@ -138,7 +138,7 @@ public class ChronicleServiceImpl implements ChronicleService {
     private Map<AppComponent, Map<UUID, Map<CollectionTemplateTypeName, UUID>>> entitySetIdsByOrgId;
 
     // app fullName -> { org1, org2, org3 }
-    private final Map<String, Set<UUID>> userAppsFullNameValues = Maps.newHashMap();
+    private final Map<String, Set<UUID>> userAppsFullNameValues = Maps.newLinkedHashMap();
 
     private final Set<String> systemAppPackageNames = Collections.synchronizedSet( new HashSet<>() );
 
@@ -1353,7 +1353,7 @@ public class ChronicleServiceImpl implements ChronicleService {
             ApiClient apiClient = prodApiClientCache.get( ApiClient.class );
             DataApi dataApi = apiClient.getDataApi();
 
-            Map<String, Set<UUID>> fullNamesMap = Maps.newHashMap(); // fullName -> { org1, org2, org3 }
+            Map<String, Set<UUID>> fullNamesMap = Maps.newLinkedHashMap(); // fullName -> { org1, org2, org3 }
 
             Map<UUID, Map<CollectionTemplateTypeName, UUID>> orgEntitySets = entitySetIdsByOrgId
                     .getOrDefault( CHRONICLE_DATA_COLLECTION, Map.of() );
@@ -1386,7 +1386,7 @@ public class ChronicleServiceImpl implements ChronicleService {
 
             logger.info( "loaded {} fullnames from user apps entity sets", fullNamesMap.keySet().size() );
         } catch ( Exception e ) {
-            logger.info( "error loading fullnames from user_apps entity sets" );
+            logger.info( "error loading fullnames from user_apps entity sets", e );
         }
     }
 


### PR DESCRIPTION
PR:

Currently, when android devices push data, we only write to `chronicle_user_apps` entity set if an entity does not exist. This is made possible by caching `general.fullname` values from the entity set and checking against the cached values during write. 

This PR extends that idea to the app configs world where each organization has its own copy of the user apps entity set.

`Map<String, Set<UUID>> userAppsFullNameValues` maps fullName values to the list of org ids where the fullName already exists, thus providing a 0(1) lookup when writing data from device. 