### PR TITLE
Optimize participant data delete

### DIFF
--- a/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
+++ b/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
@@ -175,7 +175,7 @@ public class DataDeletionService implements DataDeletionManager {
 
             // delete participants
             dataApi.deleteEntities( participantsESID, participantsToDelete, deleteType, false );
-            logger.info( "Deleted {} participants from study {} in org {}.", participantsToDelete.size(), studyId, organizationId );
+            logger.info( "Deleting {} participants from study {} in org {}.", participantsToDelete.size(), studyId, organizationId );
 
             // delete study if no participantId is specified
             if ( participantId.isPresent() ) {

--- a/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
+++ b/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
@@ -255,7 +255,7 @@ public class DataDeletionService implements DataDeletionManager {
 
             // delete participants
             userDataApi.deleteEntities( participantsESID, participantsToDelete, deleteType, false );
-            logger.info( "Deleted {} participants from study {}.", participantsToDelete.size(), studyId );
+            logger.info( "Deleting {} participants from study {}.", participantsToDelete.size(), studyId );
 
             // if no participant is specified, delete study
             if ( participantId.isPresent() ) {

--- a/src/main/java/com/openlattice/chronicle/services/enrollment/EnrollmentManager.java
+++ b/src/main/java/com/openlattice/chronicle/services/enrollment/EnrollmentManager.java
@@ -39,4 +39,6 @@ public interface EnrollmentManager {
     UUID getParticipantEntityKeyId( UUID organizationId, UUID studyId, String participantId );
 
     UUID getStudyEntityKeyId( UUID organizationId, UUID studyId );
+
+    Set<UUID> getStudyParticipants( UUID organizationId, UUID studyId );
 }

--- a/src/main/java/com/openlattice/chronicle/services/enrollment/EnrollmentService.java
+++ b/src/main/java/com/openlattice/chronicle/services/enrollment/EnrollmentService.java
@@ -31,7 +31,10 @@ import static com.openlattice.chronicle.constants.EdmConstants.OL_ID_FQN;
 import static com.openlattice.chronicle.constants.EdmConstants.STATUS_FQN;
 import static com.openlattice.chronicle.constants.EdmConstants.STRING_ID_FQN;
 import static com.openlattice.chronicle.constants.EdmConstants.VERSION_FQN;
-import static com.openlattice.chronicle.util.ChronicleServerUtil.*;
+import static com.openlattice.chronicle.util.ChronicleServerUtil.ORG_STUDY_PARTICIPANT;
+import static com.openlattice.chronicle.util.ChronicleServerUtil.ORG_STUDY_PARTICIPANT_DATASOURCE;
+import static com.openlattice.chronicle.util.ChronicleServerUtil.getFirstValueOrNull;
+import static com.openlattice.chronicle.util.ChronicleServerUtil.getParticipantEntitySetName;
 
 /**
  * @author alfoncenzioka &lt;alfonce@openlattice.com&gt;
@@ -409,6 +412,17 @@ public class EnrollmentService implements EnrollmentManager {
 
         return scheduledTasksManager.getStudyParticipants().getOrDefault( studyId, Map.of() )
                 .getOrDefault( participantId, null );
+    }
+
+    @Override
+    public Set<UUID> getStudyParticipants( UUID organizationId, UUID studyId) {
+        if (organizationId != null) {
+            Map<UUID, Map<String, UUID>> participants = scheduledTasksManager.getStudyParticipantsByOrg().getOrDefault( organizationId, Map.of() );
+
+            return Sets.newHashSet( participants.getOrDefault( studyId, Map.of() ).values() );
+        }
+
+        return Sets.newHashSet(scheduledTasksManager.getStudyParticipants().getOrDefault( studyId, Map.of() ).values());
     }
 
     @Override


### PR DESCRIPTION
PR:
- Optimize delete participants data by using cached values
- Get all participants' neighbor Ids to delete by making a single searchApi.executeFilteredEntityNeighborIdsSearch instead of an API call for each entityKeyId