### PR TITLE
chronicle super user delete legacy data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ test {
 }
 
 ext.odata_version = '4.2.0'
-ext.chronicle_api_version = '0.0.14'
+ext.chronicle_api_version = '0.0.15'
 
 dependencies {
     compile "com.google.guava:guava:${guava_version}"

--- a/src/main/java/com/openlattice/chronicle/data/ChronicleCoreAppConfig.java
+++ b/src/main/java/com/openlattice/chronicle/data/ChronicleCoreAppConfig.java
@@ -2,8 +2,10 @@ package com.openlattice.chronicle.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -74,5 +76,18 @@ public class ChronicleCoreAppConfig {
     @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getStudiesEntitySetId() {
         return studiesEntitySetId;
+    }
+
+    @JsonProperty (SerializationConstants.ENTITY_SET_IDS)
+    public Set<UUID> getAllEntitySetIds() {
+        return ImmutableSet.of(
+                hasEntitySetId,
+                participantEntitySetId,
+                participatedInEntitySetId,
+                metadataEntitySetId,
+                studiesEntitySetId,
+                notificationEntitySetId,
+                partOfEntitySetId
+        );
     }
 }

--- a/src/main/java/com/openlattice/chronicle/data/ChronicleCoreAppConfig.java
+++ b/src/main/java/com/openlattice/chronicle/data/ChronicleCoreAppConfig.java
@@ -78,7 +78,7 @@ public class ChronicleCoreAppConfig {
         return studiesEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_IDS)
+    @JsonProperty( SerializationConstants.ENTITY_SET_IDS )
     public Set<UUID> getAllEntitySetIds() {
         return ImmutableSet.of(
                 hasEntitySetId,

--- a/src/main/java/com/openlattice/chronicle/data/ChronicleDataCollectionAppConfig.java
+++ b/src/main/java/com/openlattice/chronicle/data/ChronicleDataCollectionAppConfig.java
@@ -2,7 +2,9 @@ package com.openlattice.chronicle.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -71,5 +73,18 @@ public class ChronicleDataCollectionAppConfig {
     @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getAppsDictionaryEntitySetId() {
         return appsDictionaryEntitySetId;
+    }
+
+    @JsonProperty( SerializationConstants.ENTITY_SET_IDS )
+    public Set<UUID> getAllEntitySetIds() {
+        return ImmutableSet.of(
+                recordedByEntitySetId,
+                deviceEntitySetId,
+                usedByEntitySetId,
+                userAppsEntitySetId,
+                preprocessedDataEntitySetId,
+                appDataEntitySetId,
+                appsDictionaryEntitySetId
+        );
     }
 }

--- a/src/main/java/com/openlattice/chronicle/data/ChronicleDataCollectionAppConfig.java
+++ b/src/main/java/com/openlattice/chronicle/data/ChronicleDataCollectionAppConfig.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 /**
  * @author alfoncenzioka &lt;alfonce@openlattice.com&gt;
- * <p>
+ *
  * POJO for data collection component of chronicle and its associated entity set ids
  */
 public class ChronicleDataCollectionAppConfig {

--- a/src/main/java/com/openlattice/chronicle/data/ChronicleSurveysAppConfig.java
+++ b/src/main/java/com/openlattice/chronicle/data/ChronicleSurveysAppConfig.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 /**
  * @author alfoncenzioka &lt;alfonce@openlattice.com&gt;
- * <p>
+ *
  * Represent the surveys component of chronicle and its associated entity set ids
  */
 public class ChronicleSurveysAppConfig {

--- a/src/main/java/com/openlattice/chronicle/data/ChronicleSurveysAppConfig.java
+++ b/src/main/java/com/openlattice/chronicle/data/ChronicleSurveysAppConfig.java
@@ -2,12 +2,14 @@ package com.openlattice.chronicle.data;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Set;
 import java.util.UUID;
 
 /**
  * @author alfoncenzioka &lt;alfonce@openlattice.com&gt;
- *
+ * <p>
  * Represent the surveys component of chronicle and its associated entity set ids
  */
 public class ChronicleSurveysAppConfig {
@@ -22,14 +24,14 @@ public class ChronicleSurveysAppConfig {
 
     @JsonCreator
     public ChronicleSurveysAppConfig(
-            @JsonProperty(SerializationConstants.ENTITY_SET_ID)UUID surveyEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID timeRangeEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID submissionEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID registeredForEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID respondsWithEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID addressesEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID answerEntitySetId,
-            @JsonProperty (SerializationConstants.ENTITY_SET_ID)UUID questionEntitySetId
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID surveyEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID timeRangeEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID submissionEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID registeredForEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID respondsWithEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID addressesEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID answerEntitySetId,
+            @JsonProperty( SerializationConstants.ENTITY_SET_ID ) UUID questionEntitySetId
     ) {
         this.surveyEntitySetId = surveyEntitySetId;
         this.timeRangeEntitySetId = timeRangeEntitySetId;
@@ -41,43 +43,57 @@ public class ChronicleSurveysAppConfig {
         this.answerEntitySetId = answerEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getSurveyEntitySetId() {
         return surveyEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getTimeRangeEntitySetId() {
         return timeRangeEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getSubmissionEntitySetId() {
         return submissionEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getRegisteredForEntitySetId() {
         return registeredForEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getRespondsWithEntitySetId() {
         return respondsWithEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getAddressesEntitySetId() {
         return addressesEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getQuestionEntitySetId() {
         return questionEntitySetId;
     }
 
-    @JsonProperty (SerializationConstants.ENTITY_SET_ID)
+    @JsonProperty( SerializationConstants.ENTITY_SET_ID )
     public UUID getAnswerEntitySetId() {
         return answerEntitySetId;
+    }
+
+    @JsonProperty( SerializationConstants.ENTITY_SET_IDS )
+    public Set<UUID> getAllEntitySetIds() {
+        return ImmutableSet.of(
+                surveyEntitySetId,
+                timeRangeEntitySetId,
+                submissionEntitySetId,
+                registeredForEntitySetId,
+                respondsWithEntitySetId,
+                addressesEntitySetId,
+                questionEntitySetId,
+                answerEntitySetId
+        );
     }
 }

--- a/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
+++ b/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.openlattice.chronicle.util.ChronicleServerUtil.getParticipantEntitySetName;
 
@@ -208,16 +209,14 @@ public class DataDeletionService implements DataDeletionManager {
     }
 
     private void ensureUserCanDeleteData( Set<UUID> entitySetIds, PermissionsApi permissionsApi ) {
-
-        for (UUID entitySetId : entitySetIds) {
-            AclKey aclKey = new AclKey( entitySetId );
             try {
-                permissionsApi.getAcl( aclKey );
+                Set<AclKey> aclKeys = entitySetIds.stream().map( AclKey::new ).collect(
+                        Collectors.toSet());
+                permissionsApi.getAcls( aclKeys );
             } catch ( Exception e ) {
-                logger.error( "Authorization for deleting participant data from {} failed", entitySetId );
+                logger.error( "Authorization for deleting participant data failed" );
                 throw new ForbiddenException( "insufficient permission to delete participant data" );
             }
-        }
     }
 
     private void legacyDeleteStudyData(

--- a/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
+++ b/src/main/java/com/openlattice/chronicle/services/delete/DataDeletionService.java
@@ -1,13 +1,13 @@
 package com.openlattice.chronicle.services.delete;
 
-import com.dataloom.streams.StreamUtil;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.openlattice.authorization.*;
+import com.openlattice.authorization.AclKey;
+import com.openlattice.authorization.PermissionsApi;
 import com.openlattice.chronicle.data.ChronicleCoreAppConfig;
 import com.openlattice.chronicle.data.ChronicleDataCollectionAppConfig;
 import com.openlattice.chronicle.data.ChronicleDeleteType;
@@ -22,7 +22,6 @@ import com.openlattice.controllers.exceptions.ForbiddenException;
 import com.openlattice.data.DataApi;
 import com.openlattice.data.DeleteType;
 import com.openlattice.data.requests.NeighborEntityIds;
-import com.openlattice.directory.PrincipalApi;
 import com.openlattice.entitysets.EntitySetsApi;
 import com.openlattice.search.SearchApi;
 import com.openlattice.search.requests.EntityNeighborsFilter;
@@ -31,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static com.openlattice.chronicle.util.ChronicleServerUtil.getParticipantEntitySetName;
 
@@ -206,7 +204,6 @@ public class DataDeletionService implements DataDeletionManager {
         }
     }
 
-
     private void ensureOwnerAccess( UUID studyId, PermissionsApi permissionsApi ) {
         ChronicleCoreAppConfig coreAppConfig = entitySetIdsManager
                 .getLegacyChronicleAppConfig( getParticipantEntitySetName( studyId ) );
@@ -216,7 +213,7 @@ public class DataDeletionService implements DataDeletionManager {
 
         try {
             permissionsApi.getAcl( aclKey );
-        } catch (Exception e) {
+        } catch ( Exception e ) {
             logger.error( "Authorization for deleting data from participant entity set {} failed", participantsESID );
             throw new ForbiddenException( "insufficient permission to delete data from participant entity set" );
         }


### PR DESCRIPTION
PR:
-> Regular CAFE users who own studies do not have OWNER on required edge entity sets, therefore are unable to delete participant data / studies. The workaround is to delegate deletion to chronicle super user