### PR TITLE
resolve legacy study for new upload android upload endpoint

### DIFF
--- a/src/main/kotlin/com/openlattice/chronicle/controllers/StudyController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/StudyController.kt
@@ -455,7 +455,9 @@ class StudyController @Inject constructor(
         @PathVariable(SOURCE_DEVICE_ID) datasourceId: String,
         @RequestBody data: List<SetMultimap<UUID, Any>>
     ): Int {
-        return appDataUploadService.upload(studyId, participantId, datasourceId, data)
+        val realStudyId = studyService.getStudyId(studyId)
+        checkNotNull(realStudyId) { "invalid study id" }
+        return appDataUploadService.upload(realStudyId, participantId, datasourceId, data)
     }
 
     @Timed


### PR DESCRIPTION
Fixes a future problem where currently enrolled devices would be unable to upload data after updating the android app to talk to v3 endpoints