### PR TITLE
Feature/chronicle 51 per study application package filtering for surveys

### DIFF
--- a/src/main/kotlin/com/openlattice/chronicle/auditing/AuditEventType.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/auditing/AuditEventType.kt
@@ -27,6 +27,7 @@ package com.openlattice.chronicle.auditing
  */
 enum class AuditEventType {
     ACCESS_DENIED,
+    ALLOW_APPS,
     ADD_PERMISSION,
     ASSOCIATE_STUDY,
     BACKGROUND_USAGE_DATA_DELETION,
@@ -43,6 +44,8 @@ enum class AuditEventType {
     DOWNLOAD_PARTICIPANTS_TIME_USE_DIARY_DATA,
     DOWNLOAD_PARTICIPANTS_DATA,
     ENROLL_DEVICE,
+    FILTER_APPS,
+    GET_FILTERED_APPS,
     GET_ORGANIZATION,
     GET_STUDY,
     GET_TIME_USE_DIARY_SUBMISSION,

--- a/src/main/kotlin/com/openlattice/chronicle/auditing/AuditedOperation.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/auditing/AuditedOperation.kt
@@ -1,6 +1,5 @@
 package com.openlattice.chronicle.auditing
 
-import com.openlattice.chronicle.storage.StorageResolver
 import org.slf4j.LoggerFactory
 import java.sql.Connection
 
@@ -48,19 +47,19 @@ class AuditedOperation<R>(
     }
 }
 
-class AuditedOperationBuilder<R>(
+class AuditedTransactionBuilder<R>(
     val connection: Connection,
     override val auditingManager: AuditingManager
 ) : AuditingComponent {
     private lateinit var op: (Connection) -> R
     private lateinit var auditOp: (R) -> List<AuditableEvent>
 
-    fun operation(op: (Connection) -> R): AuditedOperationBuilder<R> {
+    fun transaction(op: (Connection) -> R): AuditedTransactionBuilder<R> {
         this.op = op
         return this
     }
 
-    fun audit(auditOp: (R) -> List<AuditableEvent>): AuditedOperationBuilder<R> {
+    fun audit(auditOp: (R) -> List<AuditableEvent>): AuditedTransactionBuilder<R> {
         this.auditOp = auditOp
         return this
     }

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/CandidateController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/CandidateController.kt
@@ -3,7 +3,7 @@ package com.openlattice.chronicle.controllers
 import com.codahale.metrics.annotation.Timed
 import com.openlattice.chronicle.auditing.AuditEventType
 import com.openlattice.chronicle.auditing.AuditableEvent
-import com.openlattice.chronicle.auditing.AuditedOperationBuilder
+import com.openlattice.chronicle.auditing.AuditedTransactionBuilder
 import com.openlattice.chronicle.auditing.AuditingManager
 import com.openlattice.chronicle.authorization.AclKey
 import com.openlattice.chronicle.authorization.AuthorizationManager
@@ -79,8 +79,8 @@ class CandidateController @Inject constructor(
         ensureAuthenticated()
         ensureUninitializedId(candidate.id) { "cannot register candidate with the given id" }
         val candidateId = storageResolver.getPlatformStorage().connection.use { conn ->
-            AuditedOperationBuilder<UUID>(conn, auditingManager)
-                .operation { connection -> candidateService.registerCandidate(connection, candidate) }
+            AuditedTransactionBuilder<UUID>(conn, auditingManager)
+                .transaction { connection -> candidateService.registerCandidate(connection, candidate) }
                 .audit { candidateId ->
                     listOf(
                         AuditableEvent(

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/OrganizationController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/OrganizationController.kt
@@ -1,9 +1,6 @@
 package com.openlattice.chronicle.controllers
 
 import com.codahale.metrics.annotation.Timed
-import com.openlattice.chronicle.auditing.AuditEventType
-import com.openlattice.chronicle.auditing.AuditableEvent
-import com.openlattice.chronicle.auditing.AuditedOperationBuilder
 import com.openlattice.chronicle.auditing.AuditingManager
 import com.openlattice.chronicle.authorization.*
 import com.openlattice.chronicle.authorization.principals.Principals

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/StudyLimitsController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/StudyLimitsController.kt
@@ -38,8 +38,8 @@ class StudyLimitsController @Inject constructor(
     override fun setStudyLimits(@PathVariable(STUDY_ID) studyId: UUID, @RequestBody studyLimits: StudyLimits) {
         ensureAdminAccess()
         storageResolver.getPlatformStorage().connection.use { connection ->
-            AuditedOperationBuilder<Unit>(connection, auditingManager)
-                .operation {
+            AuditedTransactionBuilder<Unit>(connection, auditingManager)
+                .transaction {
                     studyLimitsMgr.setStudyLimits(studyId, studyLimits)
                 }.audit {
                     listOf(

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/SurveyController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/SurveyController.kt
@@ -54,15 +54,17 @@ class SurveyController @Inject constructor(
     override val authorizationManager: AuthorizationManager,
     override val auditingManager: AuditingManager,
 ) : SurveyApi, AuthorizingComponent {
+    @Timed
     @GetMapping(
         path = [STUDY_ID_PATH + FILTERED_PATH],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
-    override fun getAppsFilteredForStudyAppUsageSurvey(@PathVariable(STUDY_ID) studyId: UUID): List<String> {
+    override fun getAppsFilteredForStudyAppUsageSurvey(@PathVariable(STUDY_ID) studyId: UUID): Collection<String> {
         ensureReadAccess(AclKey(studyId))
         return surveysService.getAppsFilteredForStudyAppUsageSurvey(studyId)
     }
 
+    @Timed
     @PutMapping(
         path = [STUDY_ID_PATH + FILTERED_PATH],
         produces = [MediaType.APPLICATION_JSON_VALUE]
@@ -76,6 +78,7 @@ class SurveyController @Inject constructor(
         return ok
     }
 
+    @Timed
     @PatchMapping(
         path = [STUDY_ID_PATH + FILTERED_PATH],
         produces = [MediaType.APPLICATION_JSON_VALUE]
@@ -85,17 +88,18 @@ class SurveyController @Inject constructor(
         @RequestBody appPackages: Set<String>,
     ): OK {
         ensureWriteAccess(AclKey(studyId))
-        surveysService.filterAppForStudyAppUsageSurvey(studyId,appPackages)
+        surveysService.filterAppForStudyAppUsageSurvey(studyId, appPackages)
         return ok
     }
 
+    @Timed
     @DeleteMapping(
         path = [STUDY_ID_PATH + FILTERED_PATH],
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     override fun allowAppForStudyAppUsageSurvey(studyId: UUID, @RequestBody appPackages: Set<String>): OK {
         ensureWriteAccess(AclKey(studyId))
-        surveysService.allowAppForStudyAppUsageSurvey(studyId,appPackages)
+        surveysService.allowAppForStudyAppUsageSurvey(studyId, appPackages)
         return ok
     }
 

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/SurveyController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/SurveyController.kt
@@ -6,6 +6,7 @@ import com.openlattice.chronicle.authorization.AclKey
 import com.openlattice.chronicle.authorization.AuthorizationManager
 import com.openlattice.chronicle.authorization.AuthorizingComponent
 import com.openlattice.chronicle.base.OK
+import com.openlattice.chronicle.base.OK.Companion.ok
 import com.openlattice.chronicle.data.FileType
 import com.openlattice.chronicle.ids.HazelcastIdGenerationService
 import com.openlattice.chronicle.services.download.DataDownloadService
@@ -17,6 +18,7 @@ import com.openlattice.chronicle.survey.SurveyApi.Companion.CONTROLLER
 import com.openlattice.chronicle.survey.SurveyApi.Companion.DATA_PATH
 import com.openlattice.chronicle.survey.SurveyApi.Companion.END_DATE
 import com.openlattice.chronicle.survey.SurveyApi.Companion.FILE_NAME
+import com.openlattice.chronicle.survey.SurveyApi.Companion.FILTERED_PATH
 import com.openlattice.chronicle.survey.SurveyApi.Companion.PARTICIPANT_ID
 import com.openlattice.chronicle.survey.SurveyApi.Companion.PARTICIPANT_ID_PATH
 import com.openlattice.chronicle.survey.SurveyApi.Companion.PARTICIPANT_PATH
@@ -50,8 +52,52 @@ class SurveyController @Inject constructor(
     val downloadService: DataDownloadService,
     val idGenerationService: HazelcastIdGenerationService,
     override val authorizationManager: AuthorizationManager,
-    override val auditingManager: AuditingManager
+    override val auditingManager: AuditingManager,
 ) : SurveyApi, AuthorizingComponent {
+    @GetMapping(
+        path = [STUDY_ID_PATH + FILTERED_PATH],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    override fun getAppsFilteredForStudyAppUsageSurvey(@PathVariable(STUDY_ID) studyId: UUID): List<String> {
+        ensureReadAccess(AclKey(studyId))
+        return surveysService.getAppsFilteredForStudyAppUsageSurvey(studyId)
+    }
+
+    @PutMapping(
+        path = [STUDY_ID_PATH + FILTERED_PATH],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    override fun setAppsFilteredForStudyAppUsageSurvey(
+        @PathVariable(STUDY_ID) studyId: UUID,
+        @RequestBody appPackages: Set<String>,
+    ): OK {
+        ensureWriteAccess(AclKey(studyId))
+        surveysService.setAppsFilteredForStudyAppUsageSurvey(studyId, appPackages)
+        return ok
+    }
+
+    @PatchMapping(
+        path = [STUDY_ID_PATH + FILTERED_PATH],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    override fun filterAppForStudyAppUsageSurvey(
+        @PathVariable(STUDY_ID) studyId: UUID,
+        @RequestBody appPackages: Set<String>,
+    ): OK {
+        ensureWriteAccess(AclKey(studyId))
+        surveysService.filterAppForStudyAppUsageSurvey(studyId,appPackages)
+        return ok
+    }
+
+    @DeleteMapping(
+        path = [STUDY_ID_PATH + FILTERED_PATH],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    override fun allowAppForStudyAppUsageSurvey(studyId: UUID, @RequestBody appPackages: Set<String>): OK {
+        ensureWriteAccess(AclKey(studyId))
+        surveysService.allowAppForStudyAppUsageSurvey(studyId,appPackages)
+        return ok
+    }
 
     @Timed
     @GetMapping(
@@ -62,7 +108,7 @@ class SurveyController @Inject constructor(
         @PathVariable(STUDY_ID) studyId: UUID,
         @PathVariable(PARTICIPANT_ID) participantId: String,
         @RequestParam(value = START_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) startDateTime: OffsetDateTime,
-        @RequestParam(value = END_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) endDateTime: OffsetDateTime
+        @RequestParam(value = END_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) endDateTime: OffsetDateTime,
     ): List<AppUsage> {
         val realStudyId = studyService.getStudyId(studyId)
         checkNotNull(realStudyId) { "invalid study id" }
@@ -77,7 +123,7 @@ class SurveyController @Inject constructor(
     override fun submitAppUsageSurvey(
         @PathVariable(STUDY_ID) studyId: UUID,
         @PathVariable(PARTICIPANT_ID) participantId: String,
-        @RequestBody surveyResponses: List<AppUsage>
+        @RequestBody surveyResponses: List<AppUsage>,
     ) {
         val realStudyId = studyService.getStudyId(studyId)
         checkNotNull(realStudyId) { "invalid study id" }
@@ -91,7 +137,7 @@ class SurveyController @Inject constructor(
     )
     override fun createQuestionnaire(
         @PathVariable(STUDY_ID) studyId: UUID,
-        @RequestBody questionnaire: Questionnaire
+        @RequestBody questionnaire: Questionnaire,
     ): UUID {
         ensureWriteAccess(AclKey(studyId))
         return surveysService.createQuestionnaire(studyId, questionnaire)
@@ -103,7 +149,7 @@ class SurveyController @Inject constructor(
     )
     override fun deleteQuestionnaire(
         @PathVariable(STUDY_ID) studyId: UUID,
-        @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID
+        @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID,
     ): OK {
         ensureOwnerAccess(AclKey(studyId))
         surveysService.deleteQuestionnaire(studyId, questionnaireId)
@@ -117,7 +163,7 @@ class SurveyController @Inject constructor(
     )
     override fun getQuestionnaire(
         @PathVariable(STUDY_ID) studyId: UUID,
-        @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID
+        @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID,
     ): Questionnaire {
         return surveysService.getQuestionnaire(studyId, questionnaireId)
     }
@@ -130,7 +176,7 @@ class SurveyController @Inject constructor(
     override fun updateQuestionnaire(
         @PathVariable(STUDY_ID) studyId: UUID,
         @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID,
-        @RequestBody update: QuestionnaireUpdate
+        @RequestBody update: QuestionnaireUpdate,
     ): OK {
         ensureWriteAccess(AclKey(studyId))
         surveysService.updateQuestionnaire(studyId, questionnaireId, update)
@@ -158,7 +204,7 @@ class SurveyController @Inject constructor(
         @PathVariable(STUDY_ID) studyId: UUID,
         @PathVariable(PARTICIPANT_ID) participantId: String,
         @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID,
-        @RequestBody responses: List<QuestionnaireResponse>
+        @RequestBody responses: List<QuestionnaireResponse>,
     ): OK {
         val realStudyId = studyService.getStudyId(studyId)
         checkNotNull(realStudyId) { "invalid study id" }
@@ -169,7 +215,7 @@ class SurveyController @Inject constructor(
     override fun getQuestionnaireResponses(
         @PathVariable(STUDY_ID) studyId: UUID,
         @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID,
-        @PathVariable(TYPE) fileType: FileType
+        @PathVariable(TYPE) fileType: FileType,
     ): Iterable<Map<String, Any>> {
         ensureReadAccess(AclKey(studyId))
         return downloadService.getQuestionnaireResponses(studyId, questionnaireId)
@@ -184,8 +230,10 @@ class SurveyController @Inject constructor(
         @PathVariable(STUDY_ID) studyId: UUID,
         @PathVariable(QUESTIONNAIRE_ID) questionnaireId: UUID,
         @RequestParam(value = TYPE) fileType: FileType,
-        @RequestParam(value = FILE_NAME) fileName: String? = "Questionnaire_${questionnaireId}_${LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE)}",
-        httpServletResponse: HttpServletResponse
+        @RequestParam(value = FILE_NAME) fileName: String? = "Questionnaire_${questionnaireId}_${
+            LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE)
+        }",
+        httpServletResponse: HttpServletResponse,
     ): Iterable<Map<String, Any>> {
 
         val data = getQuestionnaireResponses(studyId, questionnaireId, fileType)

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/TimeUseDiaryController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/TimeUseDiaryController.kt
@@ -4,7 +4,7 @@ import com.codahale.metrics.annotation.Timed
 import com.google.common.base.MoreObjects
 import com.openlattice.chronicle.auditing.AuditEventType
 import com.openlattice.chronicle.auditing.AuditableEvent
-import com.openlattice.chronicle.auditing.AuditedOperationBuilder
+import com.openlattice.chronicle.auditing.AuditedTransactionBuilder
 import com.openlattice.chronicle.auditing.AuditingManager
 import com.openlattice.chronicle.authorization.AclKey
 import com.openlattice.chronicle.authorization.AuthorizationManager
@@ -76,8 +76,8 @@ class TimeUseDiaryController(
         val realStudyId = studyService.getStudyId(studyId)
         checkNotNull(realStudyId) { "invalid study id" }
         return storageResolver.getPlatformStorage().connection.use { conn ->
-            AuditedOperationBuilder<UUID>(conn, auditingManager)
-                .operation { connection ->
+            AuditedTransactionBuilder<UUID>(conn, auditingManager)
+                .transaction { connection ->
                     timeUseDiaryService.submitTimeUseDiary(
                         connection,
                         realStudyId,

--- a/src/main/kotlin/com/openlattice/chronicle/hazelcast/HazelcastMap.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/hazelcast/HazelcastMap.kt
@@ -20,11 +20,13 @@
 package com.openlattice.chronicle.hazelcast
 
 import com.auth0.json.mgmt.users.User
+import com.geekbeast.hazelcast.DelegatedStringSet
 import com.hazelcast.core.HazelcastInstance
 import com.hazelcast.map.IMap
 import com.openlattice.chronicle.authorization.*
 import com.openlattice.chronicle.mapstores.ids.Range
 import com.geekbeast.postgres.mapstores.TypedMapIdentifier
+import com.geekbeast.rhizome.KotlinDelegatedStringSet
 import com.openlattice.chronicle.study.Study
 import com.openlattice.chronicle.study.StudyLimits
 import java.util.*
@@ -68,6 +70,7 @@ class HazelcastMap<K, V> internal constructor(val name: String) : TypedMapIdenti
 //        @JvmField val DB_CREDS = HazelcastMap<AclKey, MaterializedViewAccount>("DB_CREDS")
 //        @JvmField val EXTERNAL_COLUMNS = HazelcastMap<UUID, ExternalColumn>("EXTERNAL_COLUMNS")
 //        @JvmField val EXTERNAL_TABLES = HazelcastMap<UUID, ExternalTable>("EXTERNAL_TABLES")
+        @JvmField val FILTERED_APPS = HazelcastMap<UUID, KotlinDelegatedStringSet>("FILTERED_APPS")
         @JvmField val ID_GENERATION = HazelcastMap<Long, Range>("ID_GENERATION")
 //        @JvmField val INDEXING_JOBS = HazelcastMap<UUID, DelegatedUUIDSet>("INDEXING_JOBS")
 //        @JvmField val INDEXING_LOCKS = HazelcastMap<UUID, Long>("INDEXING_LOCKS")

--- a/src/main/kotlin/com/openlattice/chronicle/mapstores/MapstoresPod.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/mapstores/MapstoresPod.kt
@@ -32,12 +32,14 @@ import com.geekbeast.rhizome.jobs.PostgresJobsMapStore
 import com.google.common.eventbus.EventBus
 import com.geekbeast.auth0.Auth0TokenProvider
 import com.geekbeast.auth0.RefreshingAuth0TokenProvider
+import com.geekbeast.rhizome.KotlinDelegatedStringSet
 import com.openlattice.chronicle.authorization.*
 import com.openlattice.chronicle.authorization.mapstores.SecurableObjectTypeMapstore
 import com.openlattice.chronicle.authorization.mapstores.UserMapstore
 import com.openlattice.chronicle.authorization.principals.PrincipalMapstore
 import com.openlattice.chronicle.ids.mapstores.IdGenerationMapstore
 import com.openlattice.chronicle.ids.mapstores.LongIdsMapstore
+import com.openlattice.chronicle.mapstores.apps.FilteredAppsMapstore
 import com.openlattice.chronicle.mapstores.authorization.PermissionMapstore
 import com.openlattice.chronicle.mapstores.authorization.PrincipalTreesMapstore
 import com.openlattice.chronicle.mapstores.ids.Range
@@ -86,6 +88,11 @@ class MapstoresPod {
     @Bean
     fun permissionMapstore(): SelfRegisteringMapStore<AceKey, AceValue> {
         return PermissionMapstore(storageResolver.getPlatformStorage(), eventBus)
+    }
+
+    @Bean
+    fun filteredAppsMapstore(): SelfRegisteringMapStore<UUID, KotlinDelegatedStringSet> {
+        return FilteredAppsMapstore(storageResolver.getPlatformStorage())
     }
 
     @Bean

--- a/src/main/kotlin/com/openlattice/chronicle/mapstores/apps/FilteredAppsMapstore.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/mapstores/apps/FilteredAppsMapstore.kt
@@ -1,0 +1,109 @@
+package com.openlattice.chronicle.mapstores.apps
+
+import com.geekbeast.postgres.PostgresArrays
+import com.geekbeast.postgres.PostgresArrays.getTextArray
+import com.geekbeast.postgres.streams.BasePostgresIterable
+import com.geekbeast.postgres.streams.PreparedStatementHolderSupplier
+import com.geekbeast.postgres.streams.StatementHolderSupplier
+import com.geekbeast.rhizome.KotlinDelegatedStringSet
+import com.geekbeast.rhizome.mapstores.TestableSelfRegisteringMapStore
+import com.hazelcast.config.MapConfig
+import com.hazelcast.config.MapStoreConfig
+import com.openlattice.chronicle.postgres.ResultSetAdapters
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.FILTERED_APPS
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.STUDIES
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.STUDY_ID
+import com.openlattice.chronicle.storage.RedshiftColumns
+import com.zaxxer.hikari.HikariDataSource
+import org.apache.commons.lang3.RandomStringUtils
+import org.slf4j.LoggerFactory
+import java.sql.ResultSet
+import java.sql.SQLException
+import java.util.*
+
+/**
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@getmethodic.com&gt;
+ */
+class FilteredAppsMapstore(
+    private val hds: HikariDataSource,
+) : TestableSelfRegisteringMapStore<UUID, KotlinDelegatedStringSet> {
+    companion object {
+        const val APP_PACKAGE_NAMES = "app_package_names"
+        private val LOAD_ALL_KEYS_SQL = """
+            SELECT ${STUDY_ID.name} FROM ${STUDIES.name}
+        """.trimIndent()
+
+        private val LOAD_SQL = """
+            SELECT ${STUDY_ID.name}, array_agg(${RedshiftColumns.APP_PACKAGE_NAME.name}) as $APP_PACKAGE_NAMES 
+            FROM ${FILTERED_APPS.name} WHERE ${STUDY_ID.name} = ANY(?)
+            GROUP BY ${STUDY_ID.name}
+        """
+
+        private val logger = LoggerFactory.getLogger(FilteredAppsMapstore::class.java)
+    }
+
+    private val mapStoreConfig = MapStoreConfig()
+        .setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER)
+        .setImplementation(this)
+        .setEnabled(true)
+        .setWriteDelaySeconds(0)
+
+    override fun load(key: UUID): KotlinDelegatedStringSet? {
+        return loadAll(listOf(key)).values.firstOrNull()
+    }
+
+    override fun loadAll(keys: Collection<UUID>): Map<UUID, KotlinDelegatedStringSet> {
+        return BasePostgresIterable(PreparedStatementHolderSupplier(hds, LOAD_SQL) {
+            it.setArray(1, PostgresArrays.createUuidArray(it.connection, keys))
+        }) {
+            ResultSetAdapters.studyId(it) to KotlinDelegatedStringSet(getTextArray(it, APP_PACKAGE_NAMES).toSet())
+        }.toMap()
+    }
+
+    override fun loadAllKeys(): Iterable<UUID> {
+        return BasePostgresIterable(
+            StatementHolderSupplier(hds, LOAD_ALL_KEYS_SQL, 50000, false, 0L)
+        ) { rs: ResultSet ->
+            try {
+                ResultSetAdapters.studyId(rs)
+            } catch (e: SQLException) {
+                logger.error("Unable to read keys for map {}.", mapName, e)
+                throw IllegalStateException("Unable to read keys.", e)
+            }
+        }
+    }
+
+    override fun getMapConfig(): MapConfig {
+        return MapConfig(mapName).setMapStoreConfig(getMapStoreConfig())
+    }
+
+    override fun getMapStoreConfig(): MapStoreConfig = mapStoreConfig
+
+    override fun getMapName(): String = "FILTERED_APPS"
+
+
+    override fun getTable(): String = FILTERED_APPS.name
+
+    override fun generateTestKey(): UUID = UUID.randomUUID()
+
+    override fun generateTestValue(): KotlinDelegatedStringSet =
+        KotlinDelegatedStringSet(setOf(RandomStringUtils.random(5, RandomStringUtils.random(5))))
+
+    override fun deleteAll(keys: MutableCollection<UUID>) {
+        throw UnsupportedOperationException("The Study Mapstore is a READ ONLY cache.")
+    }
+
+    override fun delete(key: UUID) {
+        throw UnsupportedOperationException("The Study Mapstore is a READ ONLY cache.")
+    }
+
+    override fun storeAll(map: MutableMap<UUID, KotlinDelegatedStringSet>) {
+        throw UnsupportedOperationException("The Study Mapstore is a READ ONLY cache.")
+    }
+
+    override fun store(key: UUID, value: KotlinDelegatedStringSet) {
+        throw UnsupportedOperationException("The Study Mapstore is a READ ONLY cache.")
+    }
+
+}

--- a/src/main/kotlin/com/openlattice/chronicle/organizations/ChronicleOrganizationService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/organizations/ChronicleOrganizationService.kt
@@ -60,8 +60,8 @@ class ChronicleOrganizationService(
         organization.id = idGenerationService.getNextId()
         val aclKey = AclKey(organization.id)
         storageResolver.getPlatformStorage().connection.use { conn ->
-            AuditedOperationBuilder<Unit>(conn, auditingManager)
-                .operation { connection ->
+            AuditedTransactionBuilder<Unit>(conn, auditingManager)
+                .transaction { connection ->
                     createOrganization(
                         connection,
                         Principals.getCurrentUser(),

--- a/src/main/kotlin/com/openlattice/chronicle/pods/ChronicleConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/pods/ChronicleConfigurationPod.kt
@@ -7,6 +7,7 @@ import com.geekbeast.rhizome.pods.ConfigurationLoader
 import com.openlattice.chronicle.configuration.ChronicleConfiguration
 import com.openlattice.chronicle.configuration.TwilioConfiguration
 import com.openlattice.chronicle.storage.StorageResolver
+import com.openlattice.chronicle.upgrades.AppFilteringUpgrade
 import com.openlattice.chronicle.upgrades.UpgradeService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -46,7 +47,7 @@ class ChronicleConfigurationPod {
 
     @Bean
     fun upgradeService(): PreHazelcastUpgradeService {
-        return UpgradeService(storageResolver())
+        return AppFilteringUpgrade(storageResolver())
     }
 
 }

--- a/src/main/kotlin/com/openlattice/chronicle/services/jobs/JobService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/jobs/JobService.kt
@@ -7,7 +7,7 @@ import com.geekbeast.postgres.streams.BasePostgresIterable
 import com.geekbeast.postgres.streams.PreparedStatementHolderSupplier
 import com.geekbeast.rhizome.jobs.JobStatus
 import com.openlattice.chronicle.auditing.AuditableEvent
-import com.openlattice.chronicle.auditing.AuditedOperationBuilder
+import com.openlattice.chronicle.auditing.AuditedTransactionBuilder
 import com.openlattice.chronicle.auditing.AuditingManager
 import com.openlattice.chronicle.ids.HazelcastIdGenerationService
 import com.openlattice.chronicle.ids.IdConstants
@@ -171,12 +171,12 @@ class JobService(
                 executor.execute {
                     try {
                         storageResolver.getPlatformStorage().connection.use { conn ->
-                            val (jobId, _) = AuditedOperationBuilder<Pair<UUID, List<AuditableEvent>>>(
+                            val (jobId, _) = AuditedTransactionBuilder<Pair<UUID, List<AuditableEvent>>>(
                                 conn,
                                 auditingManager
                             )
-                                .operation { connection ->
-                                    val job = lockAndGetNextJob(connection) ?: return@operation NO_JOB_FOUND
+                                .transaction { connection ->
+                                    val job = lockAndGetNextJob(connection) ?: return@transaction NO_JOB_FOUND
                                     val runner = runner.getOrDefault(
                                         job.definition.javaClass,
                                         DefaultJobRunner.getDefaultJobRunner(job.definition)

--- a/src/main/kotlin/com/openlattice/chronicle/services/notifications/NotificationService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/notifications/NotificationService.kt
@@ -12,7 +12,6 @@ import com.openlattice.chronicle.notifications.NotificationStatus
 import com.openlattice.chronicle.postgres.ResultSetAdapters
 import com.openlattice.chronicle.services.candidates.CandidateService
 import com.openlattice.chronicle.services.enrollment.EnrollmentManager
-import com.openlattice.chronicle.services.enrollment.EnrollmentService
 import com.openlattice.chronicle.services.jobs.ChronicleJob
 import com.openlattice.chronicle.services.jobs.JobService
 import com.openlattice.chronicle.services.studies.StudyService
@@ -188,8 +187,8 @@ class NotificationService(
 
     override fun sendNotifications(studyId: UUID, participantNotifications: List<ParticipantNotification>) {
         storageResolver.getPlatformStorage().connection.use { connection ->
-            AuditedOperationBuilder<Unit>(connection, auditingManager)
-                .operation { conn ->
+            AuditedTransactionBuilder<Unit>(connection, auditingManager)
+                .transaction { conn ->
 //                    val notificationOutcomes = twilioService.sendNotifications(notifications)
                     sendNotifications(conn, studyId, participantNotifications)
                 }

--- a/src/main/kotlin/com/openlattice/chronicle/services/studies/StudyService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/studies/StudyService.kt
@@ -31,6 +31,7 @@ import com.openlattice.chronicle.services.candidates.CandidateManager
 import com.openlattice.chronicle.services.enrollment.EnrollmentManager
 import com.openlattice.chronicle.services.notifications.NotificationService
 import com.openlattice.chronicle.services.studies.processors.StudyPhoneNumberGetter
+import com.openlattice.chronicle.services.surveys.SurveysManager
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.LEGACY_STUDY_IDS
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.ORGANIZATION_STUDIES
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.PARTICIPANT_STATS
@@ -85,6 +86,7 @@ class StudyService(
     private val authorizationService: AuthorizationManager,
     private val candidateService: CandidateManager,
     private val enrollmentService: EnrollmentManager,
+    private val surveysManager: SurveysManager,
     private val idGenerationService: HazelcastIdGenerationService,
     private val studyLimitsMgr: StudyLimitsManager,
     override val auditingManager: AuditingManager,
@@ -376,9 +378,10 @@ class StudyService(
     }
 
     override fun createStudy(connection: Connection, study: Study) {
-        studyLimitsMgr.initializeStudyLimits(connection, study.id)
         insertStudy(connection, study)
         insertOrgStudy(connection, study)
+        studyLimitsMgr.initializeStudyLimits(connection, study.id)
+        surveysManager.initializeFilterdApps(connection, study.id)
         authorizationService.createUnnamedSecurableObject(
             connection = connection,
             aclKey = AclKey(study.id),

--- a/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
@@ -15,56 +15,67 @@ import java.util.*
  */
 interface SurveysManager {
 
-    fun getLegacyQuestionnaire(organizationId: UUID, studyId: UUID, questionnaireEKID: UUID): LegacyChronicleQuestionnaire
+    fun getLegacyQuestionnaire(
+        organizationId: UUID,
+        studyId: UUID,
+        questionnaireEKID: UUID,
+    ): LegacyChronicleQuestionnaire
+
     fun getLegacyStudyQuestionnaires(organizationId: UUID, studyId: UUID): Map<UUID, Map<FullQualifiedName, Set<Any>>>
     fun submitLegacyQuestionnaire(
-            organizationId: UUID,
-            studyId: UUID,
-            participantId: String,
-            questionnaireResponses: Map<UUID, Map<FullQualifiedName, Set<Any>>>
+        organizationId: UUID,
+        studyId: UUID,
+        participantId: String,
+        questionnaireResponses: Map<UUID, Map<FullQualifiedName, Set<Any>>>,
     )
 
     fun submitAppUsageSurvey(
-            studyId: UUID,
-            participantId: String,
-            surveyResponses: List<AppUsage>
+        studyId: UUID,
+        participantId: String,
+        surveyResponses: List<AppUsage>,
     )
 
     fun getAppUsageData(
-            studyId: UUID,
-            participantId: String,
-            startDateTime: OffsetDateTime,
-            endDateTime: OffsetDateTime
+        studyId: UUID,
+        participantId: String,
+        startDateTime: OffsetDateTime,
+        endDateTime: OffsetDateTime,
     ): List<AppUsage>
 
     fun createQuestionnaire(
         studyId: UUID,
-        questionnaire: Questionnaire
+        questionnaire: Questionnaire,
     ): UUID
 
     fun getQuestionnaire(
         studyId: UUID,
-        questionnaireId: UUID
+        questionnaireId: UUID,
     ): Questionnaire
 
     fun deleteQuestionnaire(
         studyId: UUID,
-        questionnaireId: UUID
+        questionnaireId: UUID,
     )
+
     fun updateQuestionnaire(
         studyId: UUID,
         questionnaireId: UUID,
-        update: QuestionnaireUpdate
+        update: QuestionnaireUpdate,
     )
 
     fun getStudyQuestionnaires(
-        studyId: UUID
+        studyId: UUID,
     ): List<Questionnaire>
 
     fun submitQuestionnaireResponses(
         studyId: UUID,
         participantId: String,
         questionnaireId: UUID,
-        responses: List<QuestionnaireResponse>
+        responses: List<QuestionnaireResponse>,
     )
+
+    fun getAppsFilteredForStudyAppUsageSurvey(studyId: UUID): List<String>
+    fun setAppsFilteredForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
+    fun filterAppForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
+    fun allowAppForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
 }

--- a/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
@@ -6,6 +6,7 @@ import com.openlattice.chronicle.survey.Questionnaire
 import com.openlattice.chronicle.survey.QuestionnaireResponse
 import com.openlattice.chronicle.survey.QuestionnaireUpdate
 import org.apache.olingo.commons.api.edm.FullQualifiedName
+import java.sql.Connection
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -78,4 +79,6 @@ interface SurveysManager {
     fun setAppsFilteredForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
     fun filterAppForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
     fun allowAppForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
+    fun initializeFilterdApps(connection: Connection, studyId: UUID)
+
 }

--- a/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
@@ -74,7 +74,7 @@ interface SurveysManager {
         responses: List<QuestionnaireResponse>,
     )
 
-    fun getAppsFilteredForStudyAppUsageSurvey(studyId: UUID): List<String>
+    fun getAppsFilteredForStudyAppUsageSurvey(studyId: UUID): Collection<String>
     fun setAppsFilteredForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
     fun filterAppForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)
     fun allowAppForStudyAppUsageSurvey(studyId: UUID, appPackages: Set<String>)

--- a/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysService.kt
@@ -304,7 +304,7 @@ class SurveysService(
             ) {
                 ResultSetAdapters.appUsage(it)
 
-            }.toList().filterNot { filtered.contains(it.appPackageName) }
+            }.filterNot { filtered.contains(it.appPackageName) }
 
             logger.info(
                 "fetched {} app usage entities spanning {} to {} $STUDY_PARTICIPANT",
@@ -489,7 +489,7 @@ class SurveysService(
             throw ex
         }
     }
-    
+
     @Timed
     override fun getAppsFilteredForStudyAppUsageSurvey(studyId: UUID): Collection<String> {
         val hds = storageResolver.getPlatformStorage()

--- a/src/main/kotlin/com/openlattice/chronicle/storage/ChroniclePostgresTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/ChroniclePostgresTables.kt
@@ -295,9 +295,15 @@ class ChroniclePostgresTables {
             .primaryKey(SUBMISSION_ID)
 
         @JvmField
-        val SYSTEM_APPS = PostgresTableDefinition("system_apps")
+        val FILTERED_APPS = PostgresTableDefinition("filtered_apps")
+            .addColumns(STUDY_ID,RedshiftColumns.APP_PACKAGE_NAME)
+            .primaryKey(STUDY_ID,RedshiftColumns.APP_PACKAGE_NAME)
+
+        @JvmField
+        val SYSTEM_APPS = PostgresTableDefinition("default_filtered_apps")
             .addColumns(RedshiftColumns.APP_PACKAGE_NAME)
             .primaryKey(RedshiftColumns.APP_PACKAGE_NAME)
+
         /**
          * Authorization tables
          *
@@ -379,6 +385,9 @@ class ChroniclePostgresTables {
             STUDY_LIMITS.addIndexes(
                 PostgresColumnsIndexDefinition(STUDY_LIMITS, STUDY_ENDS).ifNotExists(),
                 PostgresColumnsIndexDefinition(STUDY_LIMITS, DATA_EXPIRES).ifNotExists()
+            )
+            FILTERED_APPS.addIndexes(
+                PostgresColumnsIndexDefinition(FILTERED_APPS, STUDY_ID).ifNotExists()
             )
         }
     }

--- a/src/main/kotlin/com/openlattice/chronicle/upgrades/AppFilteringUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/upgrades/AppFilteringUpgrade.kt
@@ -1,0 +1,57 @@
+package com.openlattice.chronicle.upgrades
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.geekbeast.hazelcast.PreHazelcastUpgradeService
+import com.geekbeast.mappers.mappers.ObjectMappers
+import com.geekbeast.postgres.PostgresArrays
+import com.openlattice.chronicle.notifications.StudyNotificationSettings
+import com.openlattice.chronicle.organizations.ChronicleDataCollectionSettings
+import com.openlattice.chronicle.sensorkit.SensorSetting
+import com.openlattice.chronicle.sensorkit.SensorType
+import com.openlattice.chronicle.settings.AppUsageFrequency
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.FILTERED_APPS
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.STUDIES
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.SYSTEM_APPS
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.STUDY_ID
+import com.openlattice.chronicle.storage.StorageResolver
+import com.openlattice.chronicle.study.*
+import org.slf4j.LoggerFactory
+import java.sql.Connection
+import java.util.*
+
+/**
+ *
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+class AppFilteringUpgrade(private val storageResolver: StorageResolver) : PreHazelcastUpgradeService {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AppFilteringUpgrade::class.java)
+        private val mapper: ObjectMapper = ObjectMappers.newJsonMapper()
+
+        /**
+         * Queries for legacy study settings by id.
+         */
+        private val RENAME_TABLE_SQL = "ALTER TABLE system_apps RENAME TO ${SYSTEM_APPS.name}"
+        private val INITIALIZE_STUDIES_SQL = """
+            INSERT INTO ${FILTERED_APPS.name} SELECT ${STUDY_ID.name} FROM $STUDIES.name} CROSS JOIN ${SYSTEM_APPS.name}
+        """.trimIndent()
+
+    }
+
+    override fun runUpgrade() {
+        storageResolver.getPlatformStorage().connection.use { connection ->
+            connection.autoCommit = false
+
+            connection.createStatement().use { s -> s.execute(RENAME_TABLE_SQL) }
+            logger.info("Renamed default filtered apps table.")
+            //Populate studies with default filtered apps
+            val count = connection.createStatement().use { s -> s.executeUpdate(INITIALIZE_STUDIES_SQL) }
+
+            connection.commit()
+            connection.autoCommit = false
+            logger.info("Upgraded $count studies")
+
+        }
+    }
+}

--- a/src/main/kotlin/com/openlattice/chronicle/upgrades/AppFilteringUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/upgrades/AppFilteringUpgrade.kt
@@ -13,6 +13,7 @@ import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.FILTE
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.STUDIES
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.SYSTEM_APPS
 import com.openlattice.chronicle.storage.PostgresColumns.Companion.STUDY_ID
+import com.openlattice.chronicle.storage.RedshiftColumns
 import com.openlattice.chronicle.storage.StorageResolver
 import com.openlattice.chronicle.study.*
 import org.slf4j.LoggerFactory
@@ -34,7 +35,8 @@ class AppFilteringUpgrade(private val storageResolver: StorageResolver) : PreHaz
          */
         private val RENAME_TABLE_SQL = "ALTER TABLE system_apps RENAME TO ${SYSTEM_APPS.name}"
         private val INITIALIZE_STUDIES_SQL = """
-            INSERT INTO ${FILTERED_APPS.name} SELECT ${STUDY_ID.name} FROM $STUDIES.name} CROSS JOIN ${SYSTEM_APPS.name}
+            INSERT INTO ${FILTERED_APPS.name} SELECT ${STUDY_ID.name}, ${RedshiftColumns.APP_PACKAGE_NAME} 
+            FROM $STUDIES.name} CROSS JOIN ${SYSTEM_APPS.name}
         """.trimIndent()
 
     }


### PR DESCRIPTION
This implements per study application package filtering for surveys. 

This is still missing one piece, which is on study creation we need to create the package filtering list in the background. It's a pretty simple query and I'll add it tomorrow.