### PR TITLE
Fix/chronicle 64

### DIFF
--- a/src/main/kotlin/com/openlattice/chronicle/controllers/SurveyController.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/SurveyController.kt
@@ -117,7 +117,7 @@ class SurveyController @Inject constructor(
         @PathVariable(PARTICIPANT_ID) participantId: String,
         @RequestParam(value = START_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) startDateTime: OffsetDateTime,
         @RequestParam(value = END_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) endDateTime: OffsetDateTime,
-        @RequestParam(THRESHOLD) thresholdInSeconds: Int?,
+        @RequestParam(THRESHOLD, required = false) thresholdInSeconds: Int?,
     ): DeviceUsage {
         val realStudyId = studyService.getStudyId(studyId)
         checkNotNull(realStudyId) { "invalid study id" }
@@ -145,7 +145,7 @@ class SurveyController @Inject constructor(
         @PathVariable(PARTICIPANT_ID) participantId: String,
         @RequestParam(value = START_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) startDateTime: OffsetDateTime,
         @RequestParam(value = END_DATE) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) endDateTime: OffsetDateTime,
-        @RequestParam(THRESHOLD) thresholdInSeconds: Int?,
+        @RequestParam(THRESHOLD, required = false) thresholdInSeconds: Int?,
     ): List<AppUsage> {
         val realStudyId = studyService.getStudyId(studyId)
         checkNotNull(realStudyId) { "invalid study id" }

--- a/src/main/kotlin/com/openlattice/chronicle/pods/ChronicleConfigurationPod.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/pods/ChronicleConfigurationPod.kt
@@ -9,6 +9,7 @@ import com.openlattice.chronicle.configuration.TwilioConfiguration
 import com.openlattice.chronicle.storage.StorageResolver
 import com.openlattice.chronicle.upgrades.AppFilteringUpgrade
 import com.openlattice.chronicle.upgrades.StudyLimitsUpgrade
+import com.openlattice.chronicle.upgrades.StudySettingsUpgrade
 import com.openlattice.chronicle.upgrades.UpgradeService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -59,6 +60,11 @@ class ChronicleConfigurationPod {
     @Bean
     fun appFilteringUpgrade(): PreHazelcastUpgradeService {
         return AppFilteringUpgrade(storageResolver(), upgradeService())
+    }
+
+    @Bean
+    fun studySettingsUpgrade() :PreHazelcastUpgradeService {
+        return StudySettingsUpgrade(storageResolver(), upgradeService())
     }
 
 }

--- a/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/surveys/SurveysManager.kt
@@ -84,4 +84,5 @@ interface SurveysManager {
         endDateTime: OffsetDateTime,
     ): DeviceUsage
 
+    fun computeAggregateUsage(appUsage: List<AppUsage>): Map<String, Double>
 }

--- a/src/main/kotlin/com/openlattice/chronicle/upgrades/StudySettingsUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/upgrades/StudySettingsUpgrade.kt
@@ -1,0 +1,99 @@
+package com.openlattice.chronicle.upgrades
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.geekbeast.hazelcast.PreHazelcastUpgradeService
+import com.geekbeast.mappers.mappers.ObjectMappers
+import com.geekbeast.postgres.PostgresArrays
+import com.geekbeast.postgres.streams.BasePostgresIterable
+import com.geekbeast.postgres.streams.StatementHolderSupplier
+import com.openlattice.chronicle.notifications.StudyNotificationSettings
+import com.openlattice.chronicle.organizations.ChronicleDataCollectionSettings
+import com.openlattice.chronicle.postgres.ResultSetAdapters
+import com.openlattice.chronicle.sensorkit.SensorSetting
+import com.openlattice.chronicle.sensorkit.SensorType
+import com.openlattice.chronicle.settings.AppUsageFrequency
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.FILTERED_APPS
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.STUDIES
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.SYSTEM_APPS
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.SETTINGS
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.STUDY_ID
+import com.openlattice.chronicle.storage.RedshiftColumns
+import com.openlattice.chronicle.storage.StorageResolver
+import com.openlattice.chronicle.study.*
+import com.openlattice.chronicle.survey.SurveySettings
+import org.slf4j.LoggerFactory
+import java.sql.Connection
+import java.util.*
+
+/**
+ * Adds in survey settings to study settings.
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+class StudySettingsUpgrade(
+    private val storageResolver: StorageResolver,
+    private val upgradeService: UpgradeService,
+) : PreHazelcastUpgradeService {
+
+    init {
+        upgradeService.registerUpgrade(this)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(StudySettingsUpgrade::class.java)
+        private val mapper: ObjectMapper = ObjectMappers.newJsonMapper()
+
+        /**
+         * Queries for legacy study settings by id.
+         */
+        private val LOAD_STUDY_SETTINGS_SQL = "SELECT ${STUDY_ID.name}, ${SETTINGS.name} FROM ${STUDIES.name}"
+        private val UPDATE_STUDY_SETTINGS_SQL =
+            "UPDATE ${STUDIES.name} SET ${SETTINGS.name} = ? WHERE ${STUDY_ID.name} = ?"
+    }
+
+    override fun runUpgrade() {
+        try {
+            doUpgrade()
+        } catch (ex: Exception) {
+            upgradeService.failUpgrade(this)
+            throw ex
+        }
+    }
+
+    private fun doUpgrade() {
+        if (upgradeService.isUpgradeComplete(this)) {
+            return
+        }
+
+        val studySettings = BasePostgresIterable(
+            StatementHolderSupplier(
+                storageResolver.getPlatformStorage(),
+                LOAD_STUDY_SETTINGS_SQL
+            )
+        ) {
+            it.getObject(
+                STUDY_ID.name,
+                UUID::class.java
+            ) to mapper.readValue<StudySettings>(it.getString(SETTINGS.name))
+        }.toMap()
+
+        val defaultSetting = mapOf(StudySettingType.Survey to SurveySettings())
+        storageResolver.getPlatformStorage().connection.use { connection ->
+            connection.autoCommit = false
+
+            val count = connection.prepareStatement(UPDATE_STUDY_SETTINGS_SQL).use { ps ->
+                studySettings.forEach { studyId, studySettings ->
+                    ps.setObject(1, studyId)
+                    ps.setObject(2, StudySettings(studySettings + defaultSetting))
+                    ps.addBatch()
+                }
+                ps.executeBatch().sum()
+            }
+
+            upgradeService.completeUpgrade(connection, this)
+            connection.commit()
+            connection.autoCommit = false
+            logger.info("Upgraded $count studies")
+        }
+    }
+}


### PR DESCRIPTION
This fixes a bug where total usage was coming back zero because SQL query was filtering down to only Move to Foreground events. 

Also implements separate threshold settings for app usage survey and device usage survey. The threshold settings can also be overridden via an optional query parameter.