### PR TITLE
Enable moving away from Redshift Storage Engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,8 +188,8 @@ dependencies {
 
     implementation (group: "org.slf4j", name: "slf4j-api", version: "${slf4j_version}")
     implementation 'com.google.firebase:firebase-admin:9.2.0'
-//    implementation "com.amazonaws:aws-java-sdk-ec2:${aws_java_sdk_version}"
     implementation 'software.amazon.awssdk:sns'
+    implementation 'software.amazon.awssdk:s3-transfer-manager'
 
     if (project.hasProperty('developmentMode') && project.developmentMode) {
         logger.quiet(project.name + " using project dependencies.")

--- a/src/main/kotlin/com/openlattice/chronicle/auditing/RedshiftAuditingManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/auditing/RedshiftAuditingManager.kt
@@ -7,6 +7,7 @@ import com.geekbeast.util.StopWatch
 import com.google.common.util.concurrent.MoreExecutors
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.AUDIT_BUFFER
 import com.openlattice.chronicle.storage.RedshiftColumns
+import com.openlattice.chronicle.storage.PostgresDataTables
 import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.AUDIT
 import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.buildMultilineInsertAuditEvents
 import com.openlattice.chronicle.storage.StorageResolver
@@ -106,6 +107,12 @@ class RedshiftAuditingManager(private val storageResolver: StorageResolver) : Au
                         })
                     }
                 }
+                if (auditEvents.isEmpty()) {
+                    connection.commit()
+                    connection.autoCommit = true
+                    return 0
+                }
+
                 val insertBatchSize = min(auditEvents.size, RS_BATCH_SIZE)
                 val dr = auditEvents.size % RS_BATCH_SIZE
 
@@ -123,42 +130,94 @@ class RedshiftAuditingManager(private val storageResolver: StorageResolver) : Au
 
                 //Commit to redshift and then commit delete. At some point we should make this so that duplicates are deleted from redshift audit log
 
-                auditStorage.second.connection.use { auditConnection ->
-                    auditConnection.autoCommit = false
-                    val insertPs = auditConnection.prepareStatement(insertSql)
-                    var finalPs: PreparedStatement? = null
-                    auditEvents.chunked(RS_BATCH_SIZE).forEach { subList ->
-                        val ps = if (subList.size == insertBatchSize) {
-                            insertPs
-                        } else {
-                            finalPs = auditConnection.prepareStatement(finalInsertSql)
-                            finalPs
-                        }!!
-                        var indexBase = 0
-                        subList.forEach { auditRow ->
-                            auditRow.forEachIndexed { index, elem ->
-                                val pgIndex = indexBase + index + 1
-                                when (elem) {
-                                    is String -> ps.setString(pgIndex, elem)
-                                    is OffsetDateTime -> ps.setObject(pgIndex, elem)
-                                    else -> throw InvalidParameterException("Unexpected class in audit row.")
+                // Write to Redshift (existing path)
+                try {
+                    auditStorage.second.connection.use { auditConnection ->
+                        auditConnection.autoCommit = false
+                        val insertPs = auditConnection.prepareStatement(insertSql)
+                        var finalPs: PreparedStatement? = null
+                        auditEvents.chunked(RS_BATCH_SIZE).forEach { subList ->
+                            val ps = if (subList.size == insertBatchSize) {
+                                insertPs
+                            } else {
+                                finalPs = auditConnection.prepareStatement(finalInsertSql)
+                                finalPs
+                            }!!
+                            var indexBase = 0
+                            subList.forEach { auditRow ->
+                                auditRow.forEachIndexed { index, elem ->
+                                    val pgIndex = indexBase + index + 1
+                                    when (elem) {
+                                        is String -> ps.setString(pgIndex, elem)
+                                        is OffsetDateTime -> ps.setObject(pgIndex, elem)
+                                        else -> throw InvalidParameterException("Unexpected class in audit row.")
+                                    }
                                 }
+                                indexBase += AUDIT.columns.size
                             }
-                            indexBase+= AUDIT.columns.size
+
+                            if (ps === insertPs)
+                                ps.addBatch()
                         }
 
-                        if (ps === insertPs)
-                            ps.addBatch()
+                        val movedRows = insertPs.executeBatch().sum() + (finalPs?.executeUpdate() ?: 0)
+                        logger.info("Moved $movedRows audit events to redshift.")
+                        auditConnection.commit()
+                        movedRows
                     }
-
-                    val movedRows = insertPs.executeBatch().sum() + (finalPs?.executeUpdate() ?: 0)
-                    logger.info("Moved $movedRows audit events to redshift.")
-                    auditConnection.commit()
-                    connection.commit()
-                    auditConnection.autoCommit = true
-                    connection.autoCommit = true
-                    movedRows
+                } catch (e: Exception) {
+                    logger.error("Failed to write audit events to Redshift.", e)
                 }
+
+                // Write to Postgres (new dual-write path)
+                val pgInsertSql = PostgresDataTables.buildMultilineInsertAuditEvents(insertBatchSize)
+                val pgFinalInsertSql = if (auditEvents.size > RS_BATCH_SIZE && dr != 0) {
+                    PostgresDataTables.buildMultilineInsertAuditEvents(dr)
+                } else {
+                    pgInsertSql
+                }
+
+                try {
+                    storageResolver.getPlatformStorage().connection.use { pgConnection ->
+                        pgConnection.autoCommit = false
+                        val pgInsertPs = pgConnection.prepareStatement(pgInsertSql)
+                        var pgFinalPs: PreparedStatement? = null
+                        auditEvents.chunked(RS_BATCH_SIZE).forEach { subList ->
+                            val ps = if (subList.size == insertBatchSize) {
+                                pgInsertPs
+                            } else {
+                                pgFinalPs = pgConnection.prepareStatement(pgFinalInsertSql)
+                                pgFinalPs
+                            }!!
+                            var indexBase = 0
+                            subList.forEach { auditRow ->
+                                auditRow.forEachIndexed { index, elem ->
+                                    val pgIndex = indexBase + index + 1
+                                    when (elem) {
+                                        is String -> ps.setString(pgIndex, elem)
+                                        is OffsetDateTime -> ps.setObject(pgIndex, elem)
+                                        else -> throw InvalidParameterException("Unexpected class in audit row.")
+                                    }
+                                }
+                                indexBase += AUDIT.columns.size
+                            }
+
+                            if (ps === pgInsertPs)
+                                ps.addBatch()
+                        }
+
+                        val pgMovedRows = pgInsertPs.executeBatch().sum() + (pgFinalPs?.executeUpdate() ?: 0)
+                        logger.info("Moved $pgMovedRows audit events to Postgres.")
+                        pgConnection.commit()
+                        pgConnection.autoCommit = true
+                    }
+                } catch (e: Exception) {
+                    logger.error("Failed to write audit events to Postgres.", e)
+                }
+
+                connection.commit()
+                connection.autoCommit = true
+                auditEvents.size
             }
         } catch (e: Exception) {
             logger.error("Unable to save data to redshift.", e)

--- a/src/main/kotlin/com/openlattice/chronicle/controllers/ChronicleServerExceptionHandler.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/ChronicleServerExceptionHandler.kt
@@ -131,15 +131,6 @@ class ChronicleServerExceptionHandler @Inject constructor(override val auditingM
         logException(req, e)
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(req: HttpServletRequest, e: Exception): ResponseEntity<ErrorsDTO> {
-        logException(req, e)
-        return ResponseEntity(
-            ErrorsDTO(ApiExceptions.OTHER_EXCEPTION, e.javaClass.simpleName + ": " + e.message),
-            HttpStatus.INTERNAL_SERVER_ERROR
-        )
-    }
-
     @ExceptionHandler(Exception::class)
     fun handleOtherExceptions(req: HttpServletRequest, e: Exception): ResponseEntity<ErrorsDTO> {
         logException(req, e)

--- a/src/main/kotlin/com/openlattice/chronicle/services/upload/AppDataUploadService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/upload/AppDataUploadService.kt
@@ -32,6 +32,7 @@ import com.openlattice.chronicle.storage.RedshiftColumns.Companion.TIMESTAMP
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.TIMEZONE
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.UPLOADED_AT
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.USERNAME
+import com.openlattice.chronicle.storage.PostgresDataTables
 import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.CHRONICLE_USAGE_EVENTS
 import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.buildMultilineInsertUsageEvents
 import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.buildTempTableOfDuplicates
@@ -300,34 +301,45 @@ class AppDataUploadService(
         try {
             if (!semaphore.tryAcquire()) return
             logger.info("Moving data from aurora to event storage.")
-            val queueEntriesByFlavor: MutableMap<PostgresFlavor, MutableList<UsageEventQueueEntry>> = mutableMapOf()
+            val allEntries = mutableListOf<UsageEventQueueEntry>()
             storageResolver.getPlatformStorage().connection.use { platform ->
                 platform.autoCommit = false
                 platform.createStatement().use { stmt ->
                     stmt.executeQuery(getMoveSql(128, UploadType.Android)).use { rs ->
                         while (rs.next()) {
                             val usageEventQueueEntries = ResultSetAdapters.usageEventQueueEntries(rs)
-                            val (flavor, _) = storageResolver.resolveAndGetFlavor(usageEventQueueEntries.studyId)
-                            queueEntriesByFlavor.getOrPut(flavor) { mutableListOf() }
-                                .addAll(usageEventQueueEntries.toEntryList())
+                            allEntries.addAll(usageEventQueueEntries.toEntryList())
                         }
                     }
-                    logger.info("Total number of entries for redshift: ${(queueEntriesByFlavor[PostgresFlavor.REDSHIFT] ?: listOf()).size}")
-                    logger.info("Total number of entries for postgres: ${(queueEntriesByFlavor[PostgresFlavor.VANILLA] ?: listOf()).size}")
-                    queueEntriesByFlavor.forEach { (postgresFlavor, usageEventQueueEntries) ->
-                        if (usageEventQueueEntries.isEmpty()) return@forEach
-                        when (postgresFlavor) {
-                            PostgresFlavor.REDSHIFT -> writeToRedshift(
-                                storageResolver.getEventStorageWithFlavor(PostgresFlavor.REDSHIFT),
-                                usageEventQueueEntries
-                            )
 
-                            PostgresFlavor.VANILLA -> writeToPostgres(
-                                storageResolver.getEventStorageWithFlavor(PostgresFlavor.VANILLA),
-                                usageEventQueueEntries
-                            )
+                    if (allEntries.isNotEmpty()) {
+                        logger.info("Total number of entries to move: ${allEntries.size}")
+                        var anyWriteSucceeded = false
 
-                            else -> throw InvalidParameterException("Invalid postgres flavor: ${postgresFlavor.name}")
+                        // Write to Redshift (existing path, backward compat)
+                        try {
+                            val (flavor, hds) = storageResolver.getDefaultEventStorage()
+                            if (flavor == PostgresFlavor.REDSHIFT || flavor == PostgresFlavor.ANY) {
+                                writeToRedshift(hds, allEntries)
+                                anyWriteSucceeded = true
+                            }
+                        } catch (ex: Exception) {
+                            logger.error("Failed to write to Redshift event storage.", ex)
+                        }
+
+                        // Write to Postgres via upsert (new path)
+                        try {
+                            writeToPostgresUpsert(storageResolver.getPlatformStorage(), allEntries)
+                            anyWriteSucceeded = true
+                        } catch (ex: Exception) {
+                            logger.error("Failed to write to Postgres event storage.", ex)
+                        }
+
+                        if (!anyWriteSucceeded) {
+                            logger.error("Both Redshift and Postgres writes failed. Rolling back upload_buffer delete.")
+                            platform.rollback()
+                            platform.autoCommit = true
+                            return
                         }
                     }
                 }
@@ -336,7 +348,7 @@ class AppDataUploadService(
             }
             logger.info("Successfully moved data to event storage.")
         } catch (ex: Exception) {
-            logger.info("Unable to move data from aurora to redshift.", ex)
+            logger.info("Unable to move data from aurora to event storage.", ex)
             throw ex
         } finally {
             semaphore.release()
@@ -623,14 +635,70 @@ class AppDataUploadService(
         studyManager.insertOrUpdateParticipantStats(participantStats)
     }
 
-    private fun writeToPostgres(
+    /**
+     * Writes usage events to Postgres using INSERT ... ON CONFLICT (dedup_hash_0, dedup_hash_1) upsert.
+     * The dedup hashes are computed in SQL via hashtextextended with seeds 0 and 1.
+     */
+    private fun writeToPostgresUpsert(
         hds: HikariDataSource,
         data: List<UsageEventQueueEntry>,
     ): Int {
-        return writeToRedshift(
-            hds,
-            data
-        )
+        if (data.isEmpty()) return 0
+
+        return hds.connection.use { connection ->
+            try {
+                val studies = data.map { it.studyId.toString() }.toSet()
+                val participants = data.map { it.participantId }.toSet()
+
+                val insertBatchSize = min(data.size, RS_BATCH_SIZE)
+                val insertSql = PostgresDataTables.buildMultilineUpsertUsageEvents(insertBatchSize)
+                val dr = data.size % RS_BATCH_SIZE
+                val finalInsertSql = if (data.size > RS_BATCH_SIZE && dr != 0) {
+                    PostgresDataTables.buildMultilineUpsertUsageEvents(dr)
+                } else {
+                    insertSql
+                }
+
+                val wc = data.chunked(RS_BATCH_SIZE).sumOf { subList ->
+                    connection.prepareStatement(if (subList.size == insertBatchSize) insertSql else finalInsertSql)
+                        .use { ps ->
+                            var indexBase = 0
+                            subList.forEach { usageEventCols ->
+                                ps.setString(indexBase + 1, usageEventCols.studyId.toString())
+                                ps.setString(indexBase + 2, usageEventCols.participantId)
+                                usageEventCols.data.values.forEach { usageEventCol ->
+                                    val colIndex = indexBase + usageEventCol.colIndex
+                                    val value = usageEventCol.value
+                                    if (value == null) {
+                                        ps.setObject(colIndex, null)
+                                    } else {
+                                        when (usageEventCol.datatype) {
+                                            PostgresDatatype.TEXT -> ps.setString(colIndex, value as String)
+                                            PostgresDatatype.TIMESTAMPTZ -> ps.setObject(colIndex, odtFromUsageEventColumn(value))
+                                            PostgresDatatype.INTEGER -> ps.setInt(colIndex, value as Int)
+                                            PostgresDatatype.BIGINT -> ps.setLong(colIndex, value as Long)
+                                            else -> ps.setObject(colIndex, value)
+                                        }
+                                    }
+                                }
+                                ps.setObject(indexBase + UPLOAD_AT_INDEX, usageEventCols.uploadedAt)
+                                indexBase += CHRONICLE_USAGE_EVENTS.columns.size
+                            }
+                            ps.executeUpdate()
+                        }
+                }
+
+                data.groupBy { it.studyId to it.participantId }.forEach { (key, qe) ->
+                    val (studyId, participantId) = key
+                    updateParticipantStats(qe.map { it.data }, studyId, participantId)
+                }
+
+                return@use wc
+            } catch (ex: Exception) {
+                logger.error("Unable to upsert data to Postgres.", ex)
+                throw ex
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/com/openlattice/chronicle/services/upload/AppDataUploadService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/upload/AppDataUploadService.kt
@@ -313,15 +313,16 @@ class AppDataUploadService(
                     }
 
                     if (allEntries.isNotEmpty()) {
-                        logger.info("Total number of entries to move: ${allEntries.size}")
-                        var anyWriteSucceeded = false
+                        logger.info("Total number of Android entries to move: ${allEntries.size}")
+                        var redshiftSuccess = false
+                        var postgresSuccess = false
 
                         // Write to Redshift (existing path, backward compat)
                         try {
                             val (flavor, hds) = storageResolver.getDefaultEventStorage()
                             if (flavor == PostgresFlavor.REDSHIFT || flavor == PostgresFlavor.ANY) {
                                 writeToRedshift(hds, allEntries)
-                                anyWriteSucceeded = true
+                                redshiftSuccess = true
                             }
                         } catch (ex: Exception) {
                             logger.error("Failed to write to Redshift event storage.", ex)
@@ -330,23 +331,25 @@ class AppDataUploadService(
                         // Write to Postgres via upsert (new path)
                         try {
                             writeToPostgresUpsert(storageResolver.getPlatformStorage(), allEntries)
-                            anyWriteSucceeded = true
+                            postgresSuccess = true
                         } catch (ex: Exception) {
                             logger.error("Failed to write to Postgres event storage.", ex)
                         }
 
-                        if (!anyWriteSucceeded) {
-                            logger.error("Both Redshift and Postgres writes failed. Rolling back upload_buffer delete.")
+                        if (!redshiftSuccess && !postgresSuccess) {
+                            logger.error("Both Redshift and Postgres writes failed for ${allEntries.size} Android entries. Rolling back upload_buffer delete.")
                             platform.rollback()
                             platform.autoCommit = true
                             return
                         }
+
+                        logger.info("Android write results: redshift={}, postgres={}", redshiftSuccess, postgresSuccess)
                     }
                 }
                 platform.commit()
+                logger.info("Committed upload_buffer delete for ${allEntries.size} Android entries.")
                 platform.autoCommit = true
             }
-            logger.info("Successfully moved data to event storage.")
         } catch (ex: Exception) {
             logger.info("Unable to move data from aurora to event storage.", ex)
             throw ex

--- a/src/main/kotlin/com/openlattice/chronicle/storage/ByteBlobDataManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/ByteBlobDataManager.kt
@@ -1,6 +1,6 @@
 package com.openlattice.chronicle.storage
 
-import com.amazonaws.HttpMethod
+import software.amazon.awssdk.services.s3.model.RequestPayer
 import java.net.URL
 import java.util.*
 
@@ -28,7 +28,7 @@ interface ByteBlobDataManager {
     fun getPresignedUrl(
             key: Any,
             expiration: Date,
-            httpMethod: HttpMethod = HttpMethod.GET,
+            httpMethod: String = "GET",
             contentType: String? = null,
             contentDisposition: String? = null
     ): URL

--- a/src/main/kotlin/com/openlattice/chronicle/storage/PostgresDataTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/PostgresDataTables.kt
@@ -1,6 +1,14 @@
 package com.openlattice.chronicle.storage
 
+import com.geekbeast.postgres.PostgresColumnDefinition
+import com.geekbeast.postgres.PostgresDatatype
 import com.geekbeast.postgres.PostgresTableDefinition
+import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.MAX_BIND_PARAMETERS
+import com.openlattice.chronicle.storage.RedshiftColumns.Companion.END_DATE_TIME
+import com.openlattice.chronicle.storage.RedshiftColumns.Companion.EXACT_RECORDED_DATE_TIME
+import com.openlattice.chronicle.storage.RedshiftColumns.Companion.SAMPLE_ID
+import com.openlattice.chronicle.storage.RedshiftColumns.Companion.START_DATE_TIME
+import com.openlattice.chronicle.storage.RedshiftColumns.Companion.UPLOADED_AT
 
 /**
  *
@@ -10,29 +18,377 @@ class PostgresDataTables {
     companion object {
         const val POSTGRES_DATA_ENVIRONMENT = "postgres_data"
 
+        /**
+         * Two salted hash columns using Postgres built-in hashtextextended().
+         * Together they form a 128-bit dedup key (seed 0 and seed 1).
+         * The UNIQUE index is on (dedup_hash_0, dedup_hash_1).
+         */
+        @JvmField
+        val DEDUP_HASH_0 = PostgresColumnDefinition("dedup_hash_0", PostgresDatatype.BIGINT).notNull()
+
+        @JvmField
+        val DEDUP_HASH_1 = PostgresColumnDefinition("dedup_hash_1", PostgresDatatype.BIGINT).notNull()
+
+        private const val DEDUP_HASH_COLUMNS_SQL = "dedup_hash_0, dedup_hash_1"
+
         @JvmField
         val CHRONICLE_USAGE_EVENTS = PostgresTableDefinition(RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name)
             .addColumns(*RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns.toTypedArray())
-            .primaryKey(*RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns.toTypedArray())
+            .addColumns(DEDUP_HASH_0, DEDUP_HASH_1)
+            .setUnique(DEDUP_HASH_0, DEDUP_HASH_1)
             .addDataSourceNames(RedshiftDataTables.REDSHIFT_DATASOURCE_NAME)
 
         @JvmField
         val CHRONICLE_USAGE_STATS = PostgresTableDefinition(RedshiftDataTables.CHRONICLE_USAGE_STATS.name)
             .addColumns(*RedshiftDataTables.CHRONICLE_USAGE_STATS.columns.toTypedArray())
-            .primaryKey(*RedshiftDataTables.CHRONICLE_USAGE_STATS.columns.toTypedArray())
+            .addColumns(DEDUP_HASH_0, DEDUP_HASH_1)
+            .setUnique(DEDUP_HASH_0, DEDUP_HASH_1)
             .addDataSourceNames(RedshiftDataTables.REDSHIFT_DATASOURCE_NAME)
 
         @JvmField
         val AUDIT = PostgresTableDefinition(RedshiftDataTables.AUDIT.name)
             .addColumns(*RedshiftDataTables.AUDIT.columns.toTypedArray())
-            .primaryKey(*RedshiftDataTables.AUDIT.columns.toTypedArray())
             .addDataSourceNames(RedshiftDataTables.REDSHIFT_DATASOURCE_NAME)
 
         @JvmField
         val IOS_SENSOR_DATA = PostgresTableDefinition(RedshiftDataTables.IOS_SENSOR_DATA.name)
             .addColumns(*RedshiftDataTables.IOS_SENSOR_DATA.columns.toTypedArray())
-            .primaryKey(*RedshiftDataTables.IOS_SENSOR_DATA.columns.toTypedArray().sliceArray(0 until 32))
+            .addColumns(DEDUP_HASH_0, DEDUP_HASH_1)
+            .setUnique(DEDUP_HASH_0, DEDUP_HASH_1)
             .addDataSourceNames(RedshiftDataTables.REDSHIFT_DATASOURCE_NAME)
 
+        /**
+         * Columns used to compute the dedup hash for usage events.
+         * All columns except uploaded_at.
+         */
+        private val USAGE_EVENTS_HASH_KEY_COLUMNS: List<PostgresColumnDefinition> by lazy {
+            (RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns - UPLOADED_AT).toList()
+        }
+
+        /**
+         * Columns excluded from the sensor data dedup hash.
+         * These are columns whose values legitimately differ between duplicate uploads
+         * (sample_id is unreliable, date bounds may vary across invocations).
+         */
+        private val SENSOR_DATA_EXCLUDED_FROM_HASH: Set<PostgresColumnDefinition> = setOf(
+            SAMPLE_ID,
+            START_DATE_TIME,
+            END_DATE_TIME,
+            EXACT_RECORDED_DATE_TIME
+        )
+
+        /**
+         * Columns used to compute the dedup hash for iOS sensor data.
+         */
+        private val SENSOR_DATA_HASH_KEY_COLUMNS: List<PostgresColumnDefinition> by lazy {
+            (RedshiftDataTables.IOS_SENSOR_DATA.columns - SENSOR_DATA_EXCLUDED_FROM_HASH).toList()
+        }
+
+        // ========== Hash & Collision Guard Helpers ==========
+
+        /**
+         * Builds the concat_ws expression used as input to hashtextextended.
+         * Uses chr(31) (unit separator) as delimiter to avoid ambiguity.
+         *
+         * @param columns The columns to include in the hash
+         * @param tableAlias Optional table alias prefix (e.g. "v" for VALUES subquery)
+         * @return SQL expression like: concat_ws(chr(31), v.col1::text, v.col2::text, ...)
+         */
+        @JvmStatic
+        fun buildConcatExpression(
+            columns: List<PostgresColumnDefinition>,
+            tableAlias: String = ""
+        ): String {
+            val prefix = if (tableAlias.isNotEmpty()) "$tableAlias." else ""
+            val concatArgs = columns.joinToString(", ") { "${prefix}${it.name}::text" }
+            return "concat_ws(chr(31), $concatArgs)"
+        }
+
+        /**
+         * Builds the two salted hash expressions using Postgres built-in hashtextextended.
+         *
+         * @param columns The columns to include in the hash
+         * @param tableAlias Optional table alias prefix
+         * @return Pair of SQL expressions: (hashtextextended(..., 0), hashtextextended(..., 1))
+         */
+        @JvmStatic
+        fun buildHashExpressions(
+            columns: List<PostgresColumnDefinition>,
+            tableAlias: String = ""
+        ): Pair<String, String> {
+            val concat = buildConcatExpression(columns, tableAlias)
+            return "hashtextextended($concat, 0)" to "hashtextextended($concat, 1)"
+        }
+
+        /**
+         * Builds the WHERE clause that guards against hash collisions on ON CONFLICT DO UPDATE.
+         * Uses IS NOT DISTINCT FROM for all columns so NULL = NULL evaluates to true,
+         * matching the current COALESCE-based dedup semantics.
+         *
+         * On a hash collision with different actual data, the WHERE fails and the row is not updated.
+         *
+         * @param tableName The target table name
+         * @param keyColumns The columns that form the logical identity of a row
+         * @return SQL WHERE clause fragment
+         */
+        @JvmStatic
+        fun buildCollisionGuard(
+            tableName: String,
+            keyColumns: List<PostgresColumnDefinition>
+        ): String {
+            return keyColumns.joinToString("\n  AND ") {
+                "$tableName.${it.name} IS NOT DISTINCT FROM EXCLUDED.${it.name}"
+            }
+        }
+
+        // ========== Upsert SQL Builders ==========
+
+        /**
+         * Builds a multiline upsert statement for usage events.
+         *
+         * Uses INSERT ... SELECT ... FROM (VALUES ...) pattern so each bind parameter is bound
+         * once and the dedup hashes are computed in SQL from the selected values via hashtextextended.
+         *
+         * Bind parameter count per row = number of original columns (same as RedshiftDataTables).
+         * Bind parameter ordering is identical to RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns.
+         *
+         * @param numLines Number of rows to insert
+         * @return SQL string with ? placeholders
+         */
+        @JvmStatic
+        fun buildMultilineUpsertUsageEvents(numLines: Int): String {
+            val originalColumns = RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns.toList()
+            check((originalColumns.size * numLines) < MAX_BIND_PARAMETERS) {
+                "Maximum number of postgres bind parameters would be exceeded with $numLines lines"
+            }
+
+            val tableName = RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name
+            val (hash0, hash1) = buildHashExpressions(USAGE_EVENTS_HASH_KEY_COLUMNS, "v")
+
+            // INSERT INTO table (original_cols, dedup_hash_0, dedup_hash_1)
+            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
+
+            // SELECT v.col1, v.col2, ..., hashtextextended(..., 0), hashtextextended(..., 1)
+            val selectCols = originalColumns.joinToString(", ") { "v.${it.name}" } +
+                    ",\n       $hash0,\n       $hash1"
+
+            // VALUES (?, ?, ...) with type casts
+            val typedParams = originalColumns.joinToString(", ") { "?::${it.datatype.sql()}" }
+            val valuesLine = "($typedParams)"
+            val valuesLines = (1..numLines).joinToString(",\n    ") { valuesLine }
+
+            // AS v(col1, col2, ...)
+            val aliases = originalColumns.joinToString(", ") { it.name }
+
+            // ON CONFLICT collision guard
+            val collisionGuard = buildCollisionGuard(tableName, USAGE_EVENTS_HASH_KEY_COLUMNS)
+
+            return """
+                INSERT INTO $tableName ($insertCols)
+                SELECT $selectCols
+                FROM (VALUES
+                    $valuesLines
+                ) AS v($aliases)
+                ON CONFLICT ($DEDUP_HASH_COLUMNS_SQL) DO UPDATE SET ${UPLOADED_AT.name} = EXCLUDED.${UPLOADED_AT.name}
+                WHERE $collisionGuard
+            """.trimIndent()
+        }
+
+        /**
+         * Builds a multiline upsert statement for iOS sensor data.
+         *
+         * On conflict, updates the excluded columns with LEAST/GREATEST semantics:
+         * - sample_id: LEAST (keep earliest)
+         * - start_date_time: LEAST (keep earliest)
+         * - end_date_time: GREATEST (keep latest)
+         * - exact_recorded_date_time: LEAST (keep earliest)
+         *
+         * Bind parameter count and ordering is identical to RedshiftDataTables.IOS_SENSOR_DATA.columns.
+         *
+         * @param numLines Number of rows to insert
+         * @return SQL string with ? placeholders
+         */
+        @JvmStatic
+        fun buildMultilineUpsertSensorEvents(numLines: Int): String {
+            val originalColumns = RedshiftDataTables.IOS_SENSOR_DATA.columns.toList()
+            check((originalColumns.size * numLines) < MAX_BIND_PARAMETERS) {
+                "Maximum number of postgres bind parameters would be exceeded with $numLines lines"
+            }
+
+            val tableName = RedshiftDataTables.IOS_SENSOR_DATA.name
+            val (hash0, hash1) = buildHashExpressions(SENSOR_DATA_HASH_KEY_COLUMNS, "v")
+
+            // INSERT INTO table (original_cols, dedup_hash_0, dedup_hash_1)
+            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
+
+            // SELECT v.col1, v.col2, ..., hashtextextended(..., 0), hashtextextended(..., 1)
+            val selectCols = originalColumns.joinToString(", ") { "v.${it.name}" } +
+                    ",\n       $hash0,\n       $hash1"
+
+            // VALUES (?, ?, ...) with type casts
+            val typedParams = originalColumns.joinToString(", ") { "?::${it.datatype.sql()}" }
+            val valuesLine = "($typedParams)"
+            val valuesLines = (1..numLines).joinToString(",\n    ") { valuesLine }
+
+            // AS v(col1, col2, ...)
+            val aliases = originalColumns.joinToString(", ") { it.name }
+
+            // ON CONFLICT update: LEAST/GREATEST for excluded columns
+            val conflictUpdate = listOf(
+                "${SAMPLE_ID.name} = LEAST($tableName.${SAMPLE_ID.name}, EXCLUDED.${SAMPLE_ID.name})",
+                "${START_DATE_TIME.name} = LEAST($tableName.${START_DATE_TIME.name}, EXCLUDED.${START_DATE_TIME.name})",
+                "${END_DATE_TIME.name} = GREATEST($tableName.${END_DATE_TIME.name}, EXCLUDED.${END_DATE_TIME.name})",
+                "${EXACT_RECORDED_DATE_TIME.name} = LEAST($tableName.${EXACT_RECORDED_DATE_TIME.name}, EXCLUDED.${EXACT_RECORDED_DATE_TIME.name})"
+            ).joinToString(",\n    ")
+
+            // Collision guard
+            val collisionGuard = buildCollisionGuard(tableName, SENSOR_DATA_HASH_KEY_COLUMNS)
+
+            return """
+                INSERT INTO $tableName ($insertCols)
+                SELECT $selectCols
+                FROM (VALUES
+                    $valuesLines
+                ) AS v($aliases)
+                ON CONFLICT ($DEDUP_HASH_COLUMNS_SQL) DO UPDATE SET
+                    $conflictUpdate
+                WHERE $collisionGuard
+            """.trimIndent()
+        }
+
+        /**
+         * Builds a multiline INSERT statement for audit events (append-only, no dedup).
+         *
+         * @param numLines Number of rows to insert
+         * @return SQL string with ? placeholders
+         */
+        @JvmStatic
+        fun buildMultilineInsertAuditEvents(numLines: Int): String {
+            val columns = RedshiftDataTables.AUDIT.columns.toList()
+            check((columns.size * numLines) < MAX_BIND_PARAMETERS) {
+                "Maximum number of postgres bind parameters would be exceeded with $numLines lines"
+            }
+
+            val tableName = RedshiftDataTables.AUDIT.name
+            val colNames = columns.joinToString(", ") { it.name }
+            val params = columns.joinToString(", ") { "?" }
+            val line = "($params)"
+            val lines = (1..numLines).joinToString(",\n") { line }
+
+            return "INSERT INTO $tableName ($colNames) VALUES\n$lines"
+        }
+
+        // ========== FDW Migration SQL Helpers ==========
+
+        /**
+         * Builds SQL to migrate usage events from a Redshift foreign table into the local Postgres table.
+         * The hashes are computed in SQL using the same hashtextextended expressions as regular upserts.
+         *
+         * @param foreignSchema The schema name where the foreign tables are mounted (e.g. "redshift_fdw")
+         * @return SQL string with ? placeholders for timestamp range (start, end)
+         */
+        @JvmStatic
+        fun buildFdwMigrationUsageEventsSql(foreignSchema: String): String {
+            val originalColumns = RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns.toList()
+            val tableName = RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name
+            val foreignTable = "$foreignSchema.$tableName"
+            val (hash0, hash1) = buildHashExpressions(USAGE_EVENTS_HASH_KEY_COLUMNS)
+
+            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
+            val selectCols = originalColumns.joinToString(", ") { it.name } +
+                    ",\n       $hash0,\n       $hash1"
+            val collisionGuard = buildCollisionGuard(tableName, USAGE_EVENTS_HASH_KEY_COLUMNS)
+
+            return """
+                INSERT INTO $tableName ($insertCols)
+                SELECT $selectCols
+                FROM $foreignTable
+                WHERE ${RedshiftColumns.TIMESTAMP.name} >= ? AND ${RedshiftColumns.TIMESTAMP.name} < ?
+                ON CONFLICT ($DEDUP_HASH_COLUMNS_SQL) DO UPDATE SET ${UPLOADED_AT.name} = EXCLUDED.${UPLOADED_AT.name}
+                WHERE $collisionGuard
+            """.trimIndent()
+        }
+
+        /**
+         * Builds SQL to migrate iOS sensor data from a Redshift foreign table into the local Postgres table.
+         *
+         * @param foreignSchema The schema name where the foreign tables are mounted
+         * @return SQL string with ? placeholders for timestamp range (start, end)
+         */
+        @JvmStatic
+        fun buildFdwMigrationSensorDataSql(foreignSchema: String): String {
+            val originalColumns = RedshiftDataTables.IOS_SENSOR_DATA.columns.toList()
+            val tableName = RedshiftDataTables.IOS_SENSOR_DATA.name
+            val foreignTable = "$foreignSchema.$tableName"
+            val (hash0, hash1) = buildHashExpressions(SENSOR_DATA_HASH_KEY_COLUMNS)
+
+            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
+            val selectCols = originalColumns.joinToString(", ") { it.name } +
+                    ",\n       $hash0,\n       $hash1"
+
+            val conflictUpdate = listOf(
+                "${SAMPLE_ID.name} = LEAST($tableName.${SAMPLE_ID.name}, EXCLUDED.${SAMPLE_ID.name})",
+                "${START_DATE_TIME.name} = LEAST($tableName.${START_DATE_TIME.name}, EXCLUDED.${START_DATE_TIME.name})",
+                "${END_DATE_TIME.name} = GREATEST($tableName.${END_DATE_TIME.name}, EXCLUDED.${END_DATE_TIME.name})",
+                "${EXACT_RECORDED_DATE_TIME.name} = LEAST($tableName.${EXACT_RECORDED_DATE_TIME.name}, EXCLUDED.${EXACT_RECORDED_DATE_TIME.name})"
+            ).joinToString(",\n    ")
+
+            val collisionGuard = buildCollisionGuard(tableName, SENSOR_DATA_HASH_KEY_COLUMNS)
+
+            return """
+                INSERT INTO $tableName ($insertCols)
+                SELECT $selectCols
+                FROM $foreignTable
+                WHERE ${RedshiftColumns.RECORDED_DATE_TIME.name} >= ? AND ${RedshiftColumns.RECORDED_DATE_TIME.name} < ?
+                ON CONFLICT ($DEDUP_HASH_COLUMNS_SQL) DO UPDATE SET
+                    $conflictUpdate
+                WHERE $collisionGuard
+            """.trimIndent()
+        }
+
+        // ========== Postgres-compatible participant stats queries ==========
+
+        const val UNIQUE_DATES = RedshiftDataTables.UNIQUE_DATES
+
+        val participantStatsIosSql = """
+                SELECT ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}, string_agg(distinct (${RedshiftColumns.RECORDED_DATE_TIME.name} at time zone ${RedshiftColumns.TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+                FROM ${RedshiftDataTables.IOS_SENSOR_DATA.name}
+                WHERE ${RedshiftColumns.STUDY_ID.name} = ?
+                GROUP BY ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}
+            """.trimIndent()
+
+        val participantStatsAndroidSql = """
+                SELECT ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}, string_agg(distinct (${RedshiftColumns.TIMESTAMP.name} at time zone ${RedshiftColumns.TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+                FROM ${RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name}
+                WHERE ${RedshiftColumns.STUDY_ID.name} = ? AND timezone != ''
+                GROUP BY ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}
+            """.trimIndent()
+
+        // ========== Column Index Helpers ==========
+
+        private val INSERT_USAGE_EVENT_COL_INDICES: Map<String, Int> by lazy {
+            RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns
+                .mapIndexed { index, col -> col.name to index + 1 }.toMap()
+        }
+
+        private val INSERT_SENSOR_DATA_COL_INDICES: Map<String, Int> by lazy {
+            RedshiftDataTables.IOS_SENSOR_DATA.columns
+                .mapIndexed { index, col -> col.name to index + 1 }.toMap()
+        }
+
+        @JvmStatic
+        fun getInsertUsageEventColumnIndex(col: PostgresColumnDefinition): Int {
+            return INSERT_USAGE_EVENT_COL_INDICES.getValue(col.name)
+        }
+
+        @JvmStatic
+        fun getInsertUsageEventColumnIndex(columnName: String): Int {
+            return INSERT_USAGE_EVENT_COL_INDICES.getValue(columnName)
+        }
+
+        @JvmStatic
+        fun getInsertSensorDataColumnIndex(col: PostgresColumnDefinition): Int {
+            return INSERT_SENSOR_DATA_COL_INDICES.getValue(col.name)
+        }
     }
 }

--- a/src/main/kotlin/com/openlattice/chronicle/storage/PostgresDataTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/PostgresDataTables.kt
@@ -165,30 +165,35 @@ class PostgresDataTables {
             val tableName = RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name
             val (hash0, hash1) = buildHashExpressions(USAGE_EVENTS_HASH_KEY_COLUMNS, "v")
 
-            // INSERT INTO table (original_cols, dedup_hash_0, dedup_hash_1)
-            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
-
-            // SELECT v.col1, v.col2, ..., hashtextextended(..., 0), hashtextextended(..., 1)
-            val selectCols = originalColumns.joinToString(", ") { "v.${it.name}" } +
-                    ",\n       $hash0,\n       $hash1"
+            // Inner SELECT: compute hashes from VALUES
+            val innerSelectCols = originalColumns.joinToString(", ") { "v.${it.name}" } +
+                    ",\n           $hash0 AS dh0,\n           $hash1 AS dh1"
 
             // VALUES (?, ?, ...) with type casts
             val typedParams = originalColumns.joinToString(", ") { "?::${it.datatype.sql()}" }
             val valuesLine = "($typedParams)"
-            val valuesLines = (1..numLines).joinToString(",\n    ") { valuesLine }
+            val valuesLines = (1..numLines).joinToString(",\n        ") { valuesLine }
 
             // AS v(col1, col2, ...)
             val aliases = originalColumns.joinToString(", ") { it.name }
+
+            // Outer SELECT: dedup within batch via ROW_NUMBER, then insert
+            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
+            val outerSelectCols = originalColumns.joinToString(", ") { it.name } + ", dh0, dh1"
 
             // ON CONFLICT collision guard
             val collisionGuard = buildCollisionGuard(tableName, USAGE_EVENTS_HASH_KEY_COLUMNS)
 
             return """
                 INSERT INTO $tableName ($insertCols)
-                SELECT $selectCols
-                FROM (VALUES
-                    $valuesLines
-                ) AS v($aliases)
+                SELECT $outerSelectCols FROM (
+                    SELECT $innerSelectCols,
+                           ROW_NUMBER() OVER (PARTITION BY $hash0, $hash1) AS rn
+                    FROM (VALUES
+                        $valuesLines
+                    ) AS v($aliases)
+                ) AS deduped
+                WHERE rn = 1
                 ON CONFLICT ($DEDUP_HASH_COLUMNS_SQL) DO UPDATE SET ${UPLOADED_AT.name} = EXCLUDED.${UPLOADED_AT.name}
                 WHERE $collisionGuard
             """.trimIndent()
@@ -218,20 +223,21 @@ class PostgresDataTables {
             val tableName = RedshiftDataTables.IOS_SENSOR_DATA.name
             val (hash0, hash1) = buildHashExpressions(SENSOR_DATA_HASH_KEY_COLUMNS, "v")
 
-            // INSERT INTO table (original_cols, dedup_hash_0, dedup_hash_1)
-            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
-
-            // SELECT v.col1, v.col2, ..., hashtextextended(..., 0), hashtextextended(..., 1)
-            val selectCols = originalColumns.joinToString(", ") { "v.${it.name}" } +
-                    ",\n       $hash0,\n       $hash1"
+            // Inner SELECT: compute hashes from VALUES
+            val innerSelectCols = originalColumns.joinToString(", ") { "v.${it.name}" } +
+                    ",\n           $hash0 AS dh0,\n           $hash1 AS dh1"
 
             // VALUES (?, ?, ...) with type casts
             val typedParams = originalColumns.joinToString(", ") { "?::${it.datatype.sql()}" }
             val valuesLine = "($typedParams)"
-            val valuesLines = (1..numLines).joinToString(",\n    ") { valuesLine }
+            val valuesLines = (1..numLines).joinToString(",\n        ") { valuesLine }
 
             // AS v(col1, col2, ...)
             val aliases = originalColumns.joinToString(", ") { it.name }
+
+            // Outer SELECT: dedup within batch via ROW_NUMBER, then insert
+            val insertCols = originalColumns.joinToString(", ") { it.name } + ", $DEDUP_HASH_COLUMNS_SQL"
+            val outerSelectCols = originalColumns.joinToString(", ") { it.name } + ", dh0, dh1"
 
             // ON CONFLICT update: LEAST/GREATEST for excluded columns
             val conflictUpdate = listOf(
@@ -246,10 +252,14 @@ class PostgresDataTables {
 
             return """
                 INSERT INTO $tableName ($insertCols)
-                SELECT $selectCols
-                FROM (VALUES
-                    $valuesLines
-                ) AS v($aliases)
+                SELECT $outerSelectCols FROM (
+                    SELECT $innerSelectCols,
+                           ROW_NUMBER() OVER (PARTITION BY $hash0, $hash1) AS rn
+                    FROM (VALUES
+                        $valuesLines
+                    ) AS v($aliases)
+                ) AS deduped
+                WHERE rn = 1
                 ON CONFLICT ($DEDUP_HASH_COLUMNS_SQL) DO UPDATE SET
                     $conflictUpdate
                 WHERE $collisionGuard

--- a/src/main/kotlin/com/openlattice/chronicle/storage/RedshiftDataTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/RedshiftDataTables.kt
@@ -407,14 +407,14 @@ class RedshiftDataTables {
 
         const val UNIQUE_DATES = "unique_dates"
         val participantStatsIosSql = """
-                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, string_agg(distinct (${RECORDED_DATE_TIME.name} at time zone ${TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, listagg(distinct TRUNC(${RECORDED_DATE_TIME.name} at time zone ${TIMEZONE.name}), ',') as $UNIQUE_DATES
                 FROM ${IOS_SENSOR_DATA.name}
                 WHERE ${STUDY_ID.name} = ?
                 GROUP BY ${STUDY_ID.name}, ${PARTICIPANT_ID.name}
             """.trimIndent()
 
         val participantStatsAndroidSql = """
-                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, string_agg(distinct (${TIMESTAMP.name} at time zone ${TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, listagg(distinct TRUNC(${TIMESTAMP.name} at time zone ${TIMEZONE.name}), ',') as $UNIQUE_DATES
                 FROM ${CHRONICLE_USAGE_EVENTS.name}
                 WHERE ${STUDY_ID.name} = ? AND timezone != ''
                 GROUP BY ${STUDY_ID.name}, ${PARTICIPANT_ID.name}

--- a/src/main/kotlin/com/openlattice/chronicle/storage/RedshiftDataTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/RedshiftDataTables.kt
@@ -407,14 +407,14 @@ class RedshiftDataTables {
 
         const val UNIQUE_DATES = "unique_dates"
         val participantStatsIosSql = """
-                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, listagg(distinct TRUNC(${RECORDED_DATE_TIME.name} at time zone ${TIMEZONE.name}), ',') as $UNIQUE_DATES
-                FROM ${IOS_SENSOR_DATA.name} 
+                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, string_agg(distinct (${RECORDED_DATE_TIME.name} at time zone ${TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+                FROM ${IOS_SENSOR_DATA.name}
                 WHERE ${STUDY_ID.name} = ?
                 GROUP BY ${STUDY_ID.name}, ${PARTICIPANT_ID.name}
             """.trimIndent()
 
         val participantStatsAndroidSql = """
-                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, listagg(distinct TRUNC(${TIMESTAMP.name} at time zone ${TIMEZONE.name}), ',') as $UNIQUE_DATES
+                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, string_agg(distinct (${TIMESTAMP.name} at time zone ${TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
                 FROM ${CHRONICLE_USAGE_EVENTS.name}
                 WHERE ${STUDY_ID.name} = ? AND timezone != ''
                 GROUP BY ${STUDY_ID.name}, ${PARTICIPANT_ID.name}

--- a/src/main/kotlin/com/openlattice/chronicle/storage/StorageResolver.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/StorageResolver.kt
@@ -26,7 +26,7 @@ class StorageResolver constructor(
         studyStorage.executeOnKey(studyId, StudyStorageUpdate(storage))
     }
 
-    fun resolve(studyId: UUID, requiredFlavor: PostgresFlavor = PostgresFlavor.REDSHIFT): HikariDataSource {
+    fun resolve(studyId: UUID, requiredFlavor: PostgresFlavor = PostgresFlavor.VANILLA): HikariDataSource {
         val (flavor, hds) = resolveAndGetFlavor(studyId)
         check(flavor == PostgresFlavor.ANY || flavor == requiredFlavor) { "Configured flavor $flavor does not much required flavor $requiredFlavor" }
         return hds
@@ -54,7 +54,7 @@ class StorageResolver constructor(
         }
     }
 
-    fun getEventStorageWithFlavor(requiredFlavor: PostgresFlavor = PostgresFlavor.REDSHIFT): HikariDataSource {
+    fun getEventStorageWithFlavor(requiredFlavor: PostgresFlavor = PostgresFlavor.VANILLA): HikariDataSource {
         val (flavor, hds) = getDefaultEventStorage()
         check(flavor == PostgresFlavor.ANY || flavor == requiredFlavor) { "Configured flavor $flavor does not match required flavor $requiredFlavor" }
         return hds

--- a/src/main/kotlin/com/openlattice/chronicle/storage/aws/AwsBlobDataService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/aws/AwsBlobDataService.kt
@@ -1,25 +1,23 @@
 package com.openlattice.chronicle.storage.aws
 
-import com.amazonaws.AmazonServiceException
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.HttpMethod
-import com.amazonaws.SdkClientException
-import com.amazonaws.auth.AWSStaticCredentialsProvider
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.retry.PredefinedBackoffStrategies
-import com.amazonaws.retry.PredefinedRetryPolicies
-import com.amazonaws.retry.RetryPolicy
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.s3.model.*
-import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.openlattice.chronicle.configuration.ChronicleConfiguration
 import com.openlattice.chronicle.storage.BinaryObjectWithMetadata
 import com.openlattice.chronicle.storage.ByteBlobDataManager
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.retry.RetryPolicy
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.*
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import java.net.URL
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.Callable
 import java.util.concurrent.Semaphore
@@ -36,43 +34,47 @@ class AwsBlobDataService(
         private val executorService: ListeningExecutorService
 ) : ByteBlobDataManager {
 
-    private val s3Credentials =
-        BasicAWSCredentials(datastoreConfiguration.accessKeyId, datastoreConfiguration.secretAccessKey)
+    private val credentials = AwsBasicCredentials.create(
+        datastoreConfiguration.accessKeyId,
+        datastoreConfiguration.secretAccessKey
+    )
+    private val credentialsProvider = StaticCredentialsProvider.create(credentials)
     private val s3 = newS3Client(datastoreConfiguration)
+    private val presigner = S3Presigner.builder()
+        .region(Region.of(datastoreConfiguration.regionName))
+        .credentialsProvider(credentialsProvider)
+        .build()
     private val semaphore = Semaphore(MAX_PARALLEL_JOBS)
 
-    private final fun newS3Client(datastoreConfiguration: ChronicleConfiguration): AmazonS3 {
-        val builder = AmazonS3ClientBuilder.standard()
-        builder.region = datastoreConfiguration.regionName
-        builder.credentials = AWSStaticCredentialsProvider(s3Credentials)
-        val retryPolicy = RetryPolicy(
-                PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
-                PredefinedBackoffStrategies.SDKDefaultBackoffStrategy(), //TODO try jitter
-                MAX_ERROR_RETRIES,
-                false
-        )
-        builder.clientConfiguration = ClientConfiguration().withRetryPolicy(retryPolicy)
-        return builder.build()
+    private fun newS3Client(datastoreConfiguration: ChronicleConfiguration): S3Client {
+        return S3Client.builder()
+            .region(Region.of(datastoreConfiguration.regionName))
+            .credentialsProvider(credentialsProvider)
+            .overrideConfiguration {
+                it.retryPolicy(RetryPolicy.builder().numRetries(MAX_ERROR_RETRIES).build())
+            }
+            .build()
     }
 
     override fun putObject(s3Key: String, binaryObjectWithMetadata: BinaryObjectWithMetadata) {
-        val metadata = ObjectMetadata()
-        val dataInputStream = binaryObjectWithMetadata.data.inputStream()
-        metadata.contentLength = dataInputStream.available().toLong()
-        metadata.contentType = binaryObjectWithMetadata.contentType
-        binaryObjectWithMetadata.contentDisposition?.let { metadata.contentDisposition = it }
+        val builder = PutObjectRequest.builder()
+            .bucket(datastoreConfiguration.bucketName)
+            .key(s3Key)
+            .contentType(binaryObjectWithMetadata.contentType)
 
-        val putRequest = PutObjectRequest(datastoreConfiguration.bucketName, s3Key, dataInputStream, metadata)
-        val transferManager = TransferManagerBuilder.standard().withS3Client(s3).build()
-        val upload = transferManager.upload(putRequest)
-        upload.waitForCompletion()
-        transferManager.shutdownNow(false)
+        binaryObjectWithMetadata.contentDisposition?.let { builder.contentDisposition(it) }
+
+        val data = binaryObjectWithMetadata.data
+        s3.putObject(builder.build(), RequestBody.fromBytes(data))
     }
 
     override fun deleteObjects(s3Keys: List<String>) {
         s3Keys.chunked(MAX_NUM_OF_OBJECTS_FOR_S3_DELETE).map { s3KeyBatch ->
-            val keysToDelete = s3KeyBatch.map { DeleteObjectsRequest.KeyVersion(it) }.toList()
-            val deleteRequest = DeleteObjectsRequest(datastoreConfiguration.bucketName).withKeys(keysToDelete)
+            val keysToDelete = s3KeyBatch.map { ObjectIdentifier.builder().key(it).build() }
+            val deleteRequest = DeleteObjectsRequest.builder()
+                .bucket(datastoreConfiguration.bucketName)
+                .delete(Delete.builder().objects(keysToDelete).build())
+                .build()
 
             try {
                 semaphore.acquire()
@@ -91,7 +93,10 @@ class AwsBlobDataService(
     }
 
     override fun deleteObject(s3Key: String) {
-        val deleteRequest = DeleteObjectRequest(datastoreConfiguration.bucketName, s3Key)
+        val deleteRequest = DeleteObjectRequest.builder()
+            .bucket(datastoreConfiguration.bucketName)
+            .key(s3Key)
+            .build()
         s3.deleteObject(deleteRequest)
     }
 
@@ -104,15 +109,15 @@ class AwsBlobDataService(
     }
 
     override fun getPresignedUrlsWithDispositions(keysToDispositions: Map<String, String?>): Map<String, URL> {
-        val expirationTime = getDefaultExpirationDateTime()
+        val ttlMillis = datastoreConfiguration.timeToLive
 
         return keysToDispositions
             .map { (key, disposition) ->
                 executorService.submit(Callable<Pair<String, URL>> {
                     key to getPresignedUrl(
                         key = key,
-                        expiration = expirationTime,
-                        httpMethod = HttpMethod.GET,
+                        expiration = Date(System.currentTimeMillis() + ttlMillis),
+                        httpMethod = "GET",
                         contentDisposition = disposition
                     )
                 })
@@ -122,24 +127,31 @@ class AwsBlobDataService(
     override fun getPresignedUrl(
         key: Any,
         expiration: Date,
-        httpMethod: HttpMethod,
+        httpMethod: String,
         contentType: String?,
         contentDisposition: String?
     ): URL {
-        val urlRequest = GeneratePresignedUrlRequest(datastoreConfiguration.bucketName, key.toString()).withMethod(
-            httpMethod
-        ).withExpiration(expiration)
-        contentType?.let { urlRequest.contentType = it }
-        contentDisposition?.let { urlRequest.responseHeaders = ResponseHeaderOverrides().withContentDisposition(it) }
-        lateinit var url: URL
-        try {
-            url = s3.generatePresignedUrl(urlRequest)
-        } catch (e: AmazonServiceException) {
-            logger.warn("Amazon couldn't process call")
-        } catch (e: SdkClientException) {
-            logger.warn("Amazon S3 couldn't be contacted or the client couldn't parse the response from S3")
+        val durationMillis = expiration.time - System.currentTimeMillis()
+        val duration = Duration.ofMillis(maxOf(durationMillis, 1000))
+
+        return try {
+            val getObjectRequest = GetObjectRequest.builder()
+                .bucket(datastoreConfiguration.bucketName)
+                .key(key.toString())
+
+            contentDisposition?.let { getObjectRequest.responseContentDisposition(it) }
+            contentType?.let { getObjectRequest.responseContentType(it) }
+
+            val presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(duration)
+                .getObjectRequest(getObjectRequest.build())
+                .build()
+
+            presigner.presignGetObject(presignRequest).url()
+        } catch (e: S3Exception) {
+            logger.warn("Amazon couldn't process call", e)
+            throw e
         }
-        return url
     }
 
     override fun getDefaultExpirationDateTime(): Date {
@@ -148,6 +160,4 @@ class AwsBlobDataService(
         expirationTime.time = timeToLive
         return expirationTime
     }
-
-
 }

--- a/src/main/kotlin/com/openlattice/chronicle/storage/local/LocalBlobDataService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/local/LocalBlobDataService.kt
@@ -1,6 +1,5 @@
 package com.openlattice.chronicle.storage.local
 
-import com.amazonaws.HttpMethod
 import com.openlattice.chronicle.storage.BinaryObjectWithMetadata
 import com.openlattice.chronicle.storage.ByteBlobDataManager
 import com.geekbeast.postgres.PostgresColumnDefinition
@@ -31,7 +30,7 @@ class LocalBlobDataService(private val hds: HikariDataSource) : ByteBlobDataMana
     }
 
     override fun getPresignedUrl(
-            key: Any, expiration: Date, httpMethod: HttpMethod, contentType: String?, contentDisposition: String?
+            key: Any, expiration: Date, httpMethod: String, contentType: String?, contentDisposition: String?
     ): URL {
         throw UnsupportedOperationException()
     }

--- a/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToEventStorageTask.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToEventStorageTask.kt
@@ -74,15 +74,16 @@ class MoveToEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskDepe
                         }
 
                         if (allEntries.isNotEmpty()) {
-                            logger.info("Total number of entries to move: ${allEntries.size}")
-                            var anyWriteSucceeded = false
+                            logger.info("Total number of Android entries to move: ${allEntries.size}")
+                            var redshiftSuccess = false
+                            var postgresSuccess = false
 
                             // Write to Redshift (existing path, backward compat)
                             try {
                                 val (flavor, hds) = storageResolver.getDefaultEventStorage()
                                 if (flavor == PostgresFlavor.REDSHIFT || flavor == PostgresFlavor.ANY) {
                                     writeToRedshift(hds, allEntries)
-                                    anyWriteSucceeded = true
+                                    redshiftSuccess = true
                                 }
                             } catch (ex: Exception) {
                                 logger.error("Failed to write to Redshift event storage.", ex)
@@ -91,23 +92,25 @@ class MoveToEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskDepe
                             // Write to Postgres via upsert (new path)
                             try {
                                 writeToPostgresUpsert(storageResolver.getPlatformStorage(), allEntries)
-                                anyWriteSucceeded = true
+                                postgresSuccess = true
                             } catch (ex: Exception) {
                                 logger.error("Failed to write to Postgres event storage.", ex)
                             }
 
-                            if (!anyWriteSucceeded) {
-                                logger.error("Both Redshift and Postgres writes failed. Rolling back upload_buffer delete.")
+                            if (!redshiftSuccess && !postgresSuccess) {
+                                logger.error("Both Redshift and Postgres writes failed for ${allEntries.size} Android entries. Rolling back upload_buffer delete.")
                                 platform.rollback()
                                 platform.autoCommit = true
                                 return
                             }
+
+                            logger.info("Android write results: redshift={}, postgres={}", redshiftSuccess, postgresSuccess)
                         }
                     }
                     platform.commit()
+                    logger.info("Committed upload_buffer delete for ${allEntries.size} Android entries.")
                     platform.autoCommit = true
                 }
-                logger.info("Successfully moved data to event storage.")
             } catch (ex: Exception) {
                 logger.info("Unable to move data from aurora to event storage.", ex)
                 throw ex

--- a/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToEventStorageTask.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToEventStorageTask.kt
@@ -12,6 +12,7 @@ import com.openlattice.chronicle.postgres.ResultSetAdapters
 import com.openlattice.chronicle.services.upload.UploadType
 import com.openlattice.chronicle.services.upload.UsageEventQueueEntry
 import com.openlattice.chronicle.storage.ChroniclePostgresTables
+import com.openlattice.chronicle.storage.PostgresDataTables
 import com.openlattice.chronicle.storage.RedshiftColumns
 import com.openlattice.chronicle.storage.RedshiftDataTables
 import com.openlattice.chronicle.storage.odtFromUsageEventColumn
@@ -61,32 +62,45 @@ class MoveToEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskDepe
         with(getDependency()) {
             try {
                 logger.info("Moving data from aurora to event storage.")
-                val queueEntriesByFlavor: MutableMap<PostgresFlavor, MutableList<UsageEventQueueEntry>> = mutableMapOf()
+                val allEntries = mutableListOf<UsageEventQueueEntry>()
                 storageResolver.getPlatformStorage().connection.use { platform ->
                     platform.autoCommit = false
                     platform.createStatement().use { stmt ->
                         stmt.executeQuery(ChroniclePostgresTables.getMoveSql(128, UploadType.Android)).use { rs ->
                             while (rs.next()) {
                                 val usageEventQueueEntries = ResultSetAdapters.usageEventQueueEntries(rs)
-                                val (flavor, _) = storageResolver.resolveAndGetFlavor(usageEventQueueEntries.studyId)
-                                queueEntriesByFlavor.getOrPut(flavor) { mutableListOf() }
-                                    .addAll(usageEventQueueEntries.toEntryList())
+                                allEntries.addAll(usageEventQueueEntries.toEntryList())
                             }
                         }
-                        logger.info("Total number of entries for redshift: ${(queueEntriesByFlavor[PostgresFlavor.REDSHIFT] ?: listOf()).size}")
-                        logger.info("Total number of entries for postgres: ${(queueEntriesByFlavor[PostgresFlavor.VANILLA] ?: listOf()).size}")
-                        queueEntriesByFlavor.forEach { (postgresFlavor, usageEventQueueEntries) ->
-                            if (usageEventQueueEntries.isEmpty()) return@forEach
-                            when (postgresFlavor) {
-                                PostgresFlavor.REDSHIFT -> writeToRedshift(
-                                    storageResolver.getEventStorageWithFlavor(PostgresFlavor.REDSHIFT),
-                                    usageEventQueueEntries
-                                )
-                                PostgresFlavor.VANILLA -> writeToPostgres(
-                                    storageResolver.getEventStorageWithFlavor(PostgresFlavor.VANILLA),
-                                    usageEventQueueEntries
-                                )
-                                else -> throw InvalidParameterException("Invalid postgres flavor: ${postgresFlavor.name}")
+
+                        if (allEntries.isNotEmpty()) {
+                            logger.info("Total number of entries to move: ${allEntries.size}")
+                            var anyWriteSucceeded = false
+
+                            // Write to Redshift (existing path, backward compat)
+                            try {
+                                val (flavor, hds) = storageResolver.getDefaultEventStorage()
+                                if (flavor == PostgresFlavor.REDSHIFT || flavor == PostgresFlavor.ANY) {
+                                    writeToRedshift(hds, allEntries)
+                                    anyWriteSucceeded = true
+                                }
+                            } catch (ex: Exception) {
+                                logger.error("Failed to write to Redshift event storage.", ex)
+                            }
+
+                            // Write to Postgres via upsert (new path)
+                            try {
+                                writeToPostgresUpsert(storageResolver.getPlatformStorage(), allEntries)
+                                anyWriteSucceeded = true
+                            } catch (ex: Exception) {
+                                logger.error("Failed to write to Postgres event storage.", ex)
+                            }
+
+                            if (!anyWriteSucceeded) {
+                                logger.error("Both Redshift and Postgres writes failed. Rolling back upload_buffer delete.")
+                                platform.rollback()
+                                platform.autoCommit = true
+                                return
                             }
                         }
                     }
@@ -95,7 +109,7 @@ class MoveToEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskDepe
                 }
                 logger.info("Successfully moved data to event storage.")
             } catch (ex: Exception) {
-                logger.info("Unable to move data from aurora to redshift.", ex)
+                logger.info("Unable to move data from aurora to event storage.", ex)
                 throw ex
             }
         }
@@ -285,14 +299,86 @@ class MoveToEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskDepe
         }
     }
 
-    private fun writeToPostgres(
+    /**
+     * Writes usage events to Postgres using INSERT ... ON CONFLICT (dedup_hash_0, dedup_hash_1) upsert.
+     * The dedup hashes are computed in SQL via hashtextextended with seeds 0 and 1, so no temp table
+     * dedup cycle is needed.
+     */
+    private fun writeToPostgresUpsert(
         hds: HikariDataSource,
         data: List<UsageEventQueueEntry>,
     ): Int {
-        return writeToRedshift(
-            hds,
-            data
-        )
+        if (data.isEmpty()) return 0
+
+        return hds.connection.use { connection ->
+            try {
+                val studies = data.map { it.studyId.toString() }.toSet()
+                val participants = data.map { it.participantId }.toSet()
+
+                val insertBatchSize = min(data.size, RS_BATCH_SIZE)
+                logger.info("Preparing Postgres upsert statement with batch size $insertBatchSize")
+                val insertSql = PostgresDataTables.buildMultilineUpsertUsageEvents(insertBatchSize)
+
+                val dr = data.size % RS_BATCH_SIZE
+                val finalInsertSql = if (data.size > RS_BATCH_SIZE && dr != 0) {
+                    logger.info("Preparing secondary Postgres upsert statement with batch size $dr")
+                    PostgresDataTables.buildMultilineUpsertUsageEvents(dr)
+                } else {
+                    insertSql
+                }
+
+                val wc = data.chunked(RS_BATCH_SIZE).sumOf { subList ->
+                    logger.info("Processing sublist of length ${subList.size} for Postgres upsert")
+                    connection.prepareStatement(if (subList.size == insertBatchSize) insertSql else finalInsertSql)
+                        .use { ps ->
+                            StopWatch(
+                                log = "Postgres upsert of ${subList.size} entries into ${RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name} with studies = {} and participants = {}",
+                                level = Level.INFO,
+                                logger = logger,
+                                studies,
+                                participants
+                            ).use {
+                                var indexBase = 0
+                                subList.forEach { usageEventCols ->
+                                    ps.setString(indexBase + 1, usageEventCols.studyId.toString())
+                                    ps.setString(indexBase + 2, usageEventCols.participantId)
+                                    usageEventCols.data.values.forEach { usageEventCol ->
+                                        val colIndex = indexBase + usageEventCol.colIndex
+                                        val value = usageEventCol.value
+
+                                        if (value == null) {
+                                            ps.setObject(colIndex, null)
+                                        } else {
+                                            when (usageEventCol.datatype) {
+                                                PostgresDatatype.TEXT -> ps.setString(colIndex, value as String)
+                                                PostgresDatatype.TIMESTAMPTZ -> ps.setObject(colIndex, odtFromUsageEventColumn(value))
+                                                PostgresDatatype.INTEGER -> ps.setInt(colIndex, value as Int)
+                                                PostgresDatatype.BIGINT -> ps.setLong(colIndex, value as Long)
+                                                else -> ps.setObject(colIndex, value)
+                                            }
+                                        }
+                                    }
+                                    ps.setObject(indexBase + UPLOAD_AT_INDEX, usageEventCols.uploadedAt)
+                                    indexBase += RedshiftDataTables.CHRONICLE_USAGE_EVENTS.columns.size
+                                }
+
+                                val insertCount = ps.executeUpdate()
+                                logger.info(
+                                    "Postgres upserted $insertCount entities for ${RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name} studies = {}, participantIds = {}",
+                                    studies,
+                                    participants
+                                )
+                                insertCount
+                            }
+                        }
+                }
+
+                return@use wc
+            } catch (ex: Exception) {
+                logger.error("Unable to upsert data to Postgres.", ex)
+                throw ex
+            }
+        }
     }
 
     override fun getInitialDelay(): Long = PERIOD

--- a/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToIosEventStorageTask.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToIosEventStorageTask.kt
@@ -16,6 +16,7 @@ import com.openlattice.chronicle.sensorkit.*
 import com.openlattice.chronicle.services.studies.StudyManager
 import com.openlattice.chronicle.services.upload.*
 import com.openlattice.chronicle.storage.ChroniclePostgresTables
+import com.openlattice.chronicle.storage.PostgresDataTables
 import com.openlattice.chronicle.storage.RedshiftColumns
 import com.openlattice.chronicle.storage.RedshiftDataTables
 import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.IOS_SENSOR_DATA
@@ -81,33 +82,45 @@ class MoveToIosEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskD
             val stmt = platform.createStatement()
             try {
                 logger.info("Moving ios data from aurora to event storage.")
-                val queueEntriesByFlavor: MutableMap<PostgresFlavor, MutableList<SensorDataRow>> = mutableMapOf()
+                val allEntries = mutableListOf<SensorDataRow>()
 
                 stmt.executeQuery(ChroniclePostgresTables.getMoveSql(128, UploadType.Ios)).use { rs ->
                     while (rs.next()) {
                         val sensorDataSamples = ResultSetAdapters.sensorDataSamples(rs)
-                        val (flavor, _) = storageResolver.resolveAndGetFlavor(sensorDataSamples.studyId)
-                        queueEntriesByFlavor.getOrPut(flavor) { mutableListOf() }
-                            .addAll(sensorDataSamples.toSensorDataRows())
+                        allEntries.addAll(sensorDataSamples.toSensorDataRows())
                     }
                 }
 
-                queueEntriesByFlavor.forEach { (postgresFlavor, sensorDataEntries) ->
-                    if (sensorDataEntries.isEmpty()) return@forEach
-                    when (postgresFlavor) {
-                        PostgresFlavor.REDSHIFT -> writeToEventStorage(
-                            storageResolver.getEventStorageWithFlavor(PostgresFlavor.REDSHIFT),
-                            sensorDataEntries,
-                            false
-                        )
+                if (allEntries.isNotEmpty()) {
+                    logger.info("Total number of iOS entries to move: ${allEntries.size}")
+                    var anyWriteSucceeded = false
 
-                        PostgresFlavor.VANILLA -> writeToEventStorage(
-                            storageResolver.getEventStorageWithFlavor(PostgresFlavor.VANILLA),
-                            sensorDataEntries,
-                            true
-                        )
+                    // Write to Redshift (existing path, backward compat)
+                    try {
+                        val (flavor, hds) = storageResolver.getDefaultEventStorage()
+                        if (flavor == PostgresFlavor.REDSHIFT || flavor == PostgresFlavor.ANY) {
+                            writeToEventStorage(hds, allEntries, false)
+                            anyWriteSucceeded = true
+                        }
+                    } catch (ex: Exception) {
+                        logger.error("Failed to write iOS data to Redshift event storage.", ex)
+                    }
 
-                        else -> throw InvalidParameterException("Invalid postgres flavor: ${postgresFlavor.name}")
+                    // Write to Postgres via upsert (new path)
+                    try {
+                        writeToPostgresUpsert(storageResolver.getPlatformStorage(), allEntries)
+                        anyWriteSucceeded = true
+                    } catch (ex: Exception) {
+                        logger.error("Failed to write iOS data to Postgres event storage.", ex)
+                    }
+
+                    if (!anyWriteSucceeded) {
+                        logger.error("Both Redshift and Postgres writes failed. Rolling back upload_buffer delete.")
+                        platform.rollback()
+                        stmt.close()
+                        platform.autoCommit = true
+                        platform.close()
+                        return
                     }
                 }
 
@@ -116,10 +129,8 @@ class MoveToIosEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskD
                 stmt.close()
                 platform.close()
                 logger.info("Successfully moved ios data to event storage.")
-                logger.info("Total number of entries for redshift: ${(queueEntriesByFlavor[PostgresFlavor.REDSHIFT] ?: listOf()).size}")
-                logger.info("Total number of entries for postgres: ${(queueEntriesByFlavor[PostgresFlavor.VANILLA] ?: listOf()).size}")
             } catch (ex: Exception) {
-                logger.info("Unable to move data from aurora to redshift.", ex)
+                logger.info("Unable to move ios data from aurora to event storage.", ex)
                 platform.rollback()
                 stmt.close()
                 platform.autoCommit = true
@@ -280,6 +291,69 @@ class MoveToIosEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskD
             }
 
             //Process all the participant updates. Being lazy hear since I don't have them batched.
+            data.forEach {
+                updateParticipantStats(
+                    it.studyId,
+                    it.participantId,
+                    mapOf(it.sensorType to listOf(it.row)),
+                    getDependency().studyService
+                )
+            }
+            w
+        }
+    }
+
+    /**
+     * Writes iOS sensor data to Postgres using INSERT ... ON CONFLICT (dedup_hash_0, dedup_hash_1) upsert.
+     * The dedup hashes are computed in SQL via hashtextextended with seeds 0 and 1.
+     * On conflict, updates excluded columns with LEAST/GREATEST semantics.
+     */
+    private fun writeToPostgresUpsert(
+        hds: HikariDataSource,
+        data: List<SensorDataRow>,
+    ): Int {
+        val studies = data.map { it.studyId.toString() }.toSet()
+        val participants = data.map { it.participantId }.toSet()
+
+        return StopWatch(
+            log = "Postgres upsert of ${data.size} iOS entries to sensor storage.",
+            level = Level.INFO,
+            logger = logger
+        ).use {
+            val w = hds.connection.use { connection ->
+                val insertBatchSize = min(data.size, RS_BATCH_SIZE)
+                logger.info("Preparing Postgres upsert statement (sensor data) with batch size $insertBatchSize")
+                val insertSql = PostgresDataTables.buildMultilineUpsertSensorEvents(insertBatchSize)
+
+                val dr = data.size % RS_BATCH_SIZE
+                val finalInsertSql = if (data.size > RS_BATCH_SIZE && dr != 0) {
+                    logger.info("Preparing secondary Postgres upsert statement with batch size $dr")
+                    PostgresDataTables.buildMultilineUpsertSensorEvents(dr)
+                } else {
+                    insertSql
+                }
+
+                data.chunked(insertBatchSize).sumOf { sensorDataRows ->
+                    val ps = if (insertBatchSize == sensorDataRows.size) {
+                        connection.prepareStatement(insertSql)
+                    } else {
+                        connection.prepareStatement(finalInsertSql)
+                    }
+
+                    ps.use {
+                        var offset = 0
+                        sensorDataRows.forEach { row ->
+                            writeSensorDataToRedshift(
+                                ps, offset, row.studyId, row.participantId, row.sensorType, row.row
+                            )
+                            offset += RedshiftDataTables.IOS_SENSOR_DATA.columns.size
+                        }
+                        ps.executeUpdate()
+                    }
+                }
+            }
+
+            // Update participant stats
             data.forEach {
                 updateParticipantStats(
                     it.studyId,

--- a/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToIosEventStorageTask.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/tasks/MoveToIosEventStorageTask.kt
@@ -93,14 +93,15 @@ class MoveToIosEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskD
 
                 if (allEntries.isNotEmpty()) {
                     logger.info("Total number of iOS entries to move: ${allEntries.size}")
-                    var anyWriteSucceeded = false
+                    var redshiftSuccess = false
+                    var postgresSuccess = false
 
                     // Write to Redshift (existing path, backward compat)
                     try {
                         val (flavor, hds) = storageResolver.getDefaultEventStorage()
                         if (flavor == PostgresFlavor.REDSHIFT || flavor == PostgresFlavor.ANY) {
                             writeToEventStorage(hds, allEntries, false)
-                            anyWriteSucceeded = true
+                            redshiftSuccess = true
                         }
                     } catch (ex: Exception) {
                         logger.error("Failed to write iOS data to Redshift event storage.", ex)
@@ -109,26 +110,28 @@ class MoveToIosEventStorageTask : HazelcastFixedRateTask<MoveToEventStorageTaskD
                     // Write to Postgres via upsert (new path)
                     try {
                         writeToPostgresUpsert(storageResolver.getPlatformStorage(), allEntries)
-                        anyWriteSucceeded = true
+                        postgresSuccess = true
                     } catch (ex: Exception) {
                         logger.error("Failed to write iOS data to Postgres event storage.", ex)
                     }
 
-                    if (!anyWriteSucceeded) {
-                        logger.error("Both Redshift and Postgres writes failed. Rolling back upload_buffer delete.")
+                    if (!redshiftSuccess && !postgresSuccess) {
+                        logger.error("Both Redshift and Postgres writes failed for ${allEntries.size} iOS entries. Rolling back upload_buffer delete.")
                         platform.rollback()
                         stmt.close()
                         platform.autoCommit = true
                         platform.close()
                         return
                     }
+
+                    logger.info("iOS write results: redshift={}, postgres={}", redshiftSuccess, postgresSuccess)
                 }
 
                 platform.commit()
+                logger.info("Committed upload_buffer delete for ${allEntries.size} iOS entries.")
                 platform.autoCommit = true
                 stmt.close()
                 platform.close()
-                logger.info("Successfully moved ios data to event storage.")
             } catch (ex: Exception) {
                 logger.info("Unable to move ios data from aurora to event storage.", ex)
                 platform.rollback()

--- a/src/main/kotlin/com/openlattice/chronicle/storage/tasks/RecalculateParticipantStatsTask.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/tasks/RecalculateParticipantStatsTask.kt
@@ -10,10 +10,11 @@ import com.openlattice.chronicle.mapstores.stats.ParticipantKey
 import com.openlattice.chronicle.participants.ParticipantStats
 import com.openlattice.chronicle.postgres.ResultSetAdapters
 import com.openlattice.chronicle.services.studies.StudyManager
+import com.geekbeast.configuration.postgres.PostgresFlavor
+import com.openlattice.chronicle.storage.PostgresDataTables
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.PARTICIPANT_ID
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.STUDY_ID
-import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.participantStatsAndroidSql
-import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.participantStatsIosSql
+import com.openlattice.chronicle.storage.RedshiftDataTables
 import com.zaxxer.hikari.HikariDataSource
 import org.slf4j.LoggerFactory
 import java.security.InvalidParameterException
@@ -61,10 +62,10 @@ class RecalculateParticipantStatsTask : HazelcastFixedRateTask<RecalculatePartic
     private fun recalculateParticipantStats() {
         logger.info("Starting recalculation of participant stats...")
         with(getDependency()) {
-            val (_, events) = storageResolver.getDefaultEventStorage()
+            val (flavor, events) = storageResolver.getDefaultEventStorage()
             val studyIds = studyService.getAllStudyIds()
-            recalculateParticipantStats(studyService, studyIds, events, ParticipantStat.Ios)
-            recalculateParticipantStats(studyService, studyIds, events, ParticipantStat.Android)
+            recalculateParticipantStats(studyService, studyIds, events, ParticipantStat.Ios, flavor)
+            recalculateParticipantStats(studyService, studyIds, events, ParticipantStat.Android, flavor)
         }
     }
 
@@ -72,11 +73,12 @@ class RecalculateParticipantStatsTask : HazelcastFixedRateTask<RecalculatePartic
         studyService: StudyManager,
         studyIds: Iterable<UUID>,
         hds: HikariDataSource,
-        statType: ParticipantStat
+        statType: ParticipantStat,
+        flavor: PostgresFlavor
     ) {
         val sql = when (statType) {
-            ParticipantStat.Ios -> participantStatsIosSql
-            ParticipantStat.Android -> participantStatsAndroidSql
+            ParticipantStat.Ios -> if (flavor == PostgresFlavor.REDSHIFT) RedshiftDataTables.participantStatsIosSql else PostgresDataTables.participantStatsIosSql
+            ParticipantStat.Android -> if (flavor == PostgresFlavor.REDSHIFT) RedshiftDataTables.participantStatsAndroidSql else PostgresDataTables.participantStatsAndroidSql
             ParticipantStat.Tud -> throw InvalidParameterException("Not yet implemented for time use diary.")
         }
         studyIds.asSequence().forEach { studyId ->

--- a/src/main/resources/redshift_fdw_setup.sql
+++ b/src/main/resources/redshift_fdw_setup.sql
@@ -1,0 +1,168 @@
+-- ============================================================================
+-- Foreign Data Wrapper Setup: Aurora -> Redshift
+-- ============================================================================
+-- This sets up postgres_fdw so Aurora can read from Redshift tables directly.
+-- Run on the Aurora/Postgres instance.
+--
+-- Fill in your Redshift connection details in Step 2 and Step 3.
+-- ============================================================================
+
+-- Step 1: Install extensions
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+-- Step 2: Create foreign server pointing to Redshift
+-- Replace host, port, dbname with your Redshift cluster details.
+CREATE SERVER IF NOT EXISTS redshift
+    FOREIGN DATA WRAPPER postgres_fdw
+    OPTIONS (
+        host 'your-cluster.region.redshift.amazonaws.com',
+        port '5439',
+        dbname 'your_database',
+        fetch_size '10000'
+    );
+
+-- Step 3: Create user mapping
+-- Replace user/password with Redshift credentials.
+CREATE USER MAPPING IF NOT EXISTS FOR current_user
+    SERVER redshift
+    OPTIONS (
+        user 'redshift_user',
+        password 'redshift_password'
+    );
+
+-- Step 4: Create foreign schema
+CREATE SCHEMA IF NOT EXISTS redshift_fdw;
+
+-- Step 5: Create foreign tables
+-- These match the Redshift table schemas exactly.
+
+-- 5a: chronicle_usage_events
+CREATE FOREIGN TABLE IF NOT EXISTS redshift_fdw.chronicle_usage_events (
+    study_id        varchar(36) NOT NULL,
+    participant_id  text NOT NULL,
+    app_package_name text,
+    interaction_type text,
+    event_type      integer NOT NULL,
+    event_timestamp timestamptz,
+    timezone        text,
+    username        text,
+    application_label text,
+    uploaded_at     timestamptz
+)
+SERVER redshift
+OPTIONS (schema_name 'public', table_name 'chronicle_usage_events');
+
+-- 5b: chronicle_usage_stats
+CREATE FOREIGN TABLE IF NOT EXISTS redshift_fdw.chronicle_usage_stats (
+    study_id        varchar(36) NOT NULL,
+    participant_id  text NOT NULL,
+    app_package_name text,
+    interaction_type text,
+    start_time      timestamptz,
+    end_time        timestamptz,
+    duration        bigint,
+    event_timestamp timestamptz,
+    timezone        text,
+    application_label text
+)
+SERVER redshift
+OPTIONS (schema_name 'public', table_name 'chronicle_usage_stats');
+
+-- 5c: sensor_data (iOS)
+CREATE FOREIGN TABLE IF NOT EXISTS redshift_fdw.sensor_data (
+    -- shared sensor columns
+    study_id            varchar(36) NOT NULL,
+    participant_id      text NOT NULL,
+    sample_id           varchar(36) NOT NULL,
+    sensor_type         text NOT NULL,
+    sample_duration     double precision NOT NULL,
+    recordeddate        timestamptz,
+    datetimestart       timestamptz,
+    datetimeend         timestamptz,
+    timezone            text,
+    device_version      text NOT NULL,
+    device_name         text NOT NULL,
+    device_model        text NOT NULL,
+    device_system_name  text NOT NULL,
+    -- device usage
+    total_screen_wakes  integer,
+    total_unlock_duration double precision,
+    total_unlocks       integer,
+    app_category        text,
+    app_usage_time      double precision,
+    text_input_source   text,
+    text_input_duration double precision,
+    bundle_identifier   text,
+    app_category_web_duration double precision,
+    -- phone usage
+    total_incoming_calls integer,
+    total_outgoing_calls integer,
+    total_call_duration double precision,
+    total_unique_contacts integer,
+    -- messages usage
+    total_incoming_messages integer,
+    total_outgoing_messages integer,
+    -- keyboard metrics
+    total_words         integer,
+    total_altered_words integer,
+    total_taps          integer,
+    total_drags         integer,
+    total_deletes       integer,
+    total_emojis        integer,
+    total_paths         integer,
+    total_path_time     double precision,
+    total_path_length   double precision,
+    total_autocorrections integer,
+    total_space_corrections integer,
+    total_transposition_corrections integer,
+    insert_key_corrections integer,
+    total_retro_corrections integer,
+    total_skip_touch_corrections integer,
+    total_near_key_corrections integer,
+    total_substitution_corrections integer,
+    total_test_hit_corrections integer,
+    total_typing_duration double precision,
+    total_path_pauses   integer,
+    total_pauses        integer,
+    total_typing_episodes integer,
+    sentiment           text,
+    sentiment_word_count integer,
+    sentiment_emoji_count integer,
+    typing_speed        double precision,
+    path_typing_speed   double precision,
+    -- utility
+    exact_recordeddate  timestamptz
+)
+SERVER redshift
+OPTIONS (schema_name 'public', table_name 'sensor_data');
+
+-- 5d: audit
+CREATE FOREIGN TABLE IF NOT EXISTS redshift_fdw.audit (
+    acl_key             varchar(256) NOT NULL,
+    id                  varchar(36) NOT NULL,
+    principal_type      varchar(128) NOT NULL,
+    principal_id        varchar(256) NOT NULL,
+    audit_event_type    varchar(256) NOT NULL,
+    study_id            varchar(36) NOT NULL,
+    organization_id     varchar(36) NOT NULL,
+    description         varchar(256) NOT NULL,
+    data                varchar(65535) NOT NULL,
+    event_timestamp     timestamptz
+)
+SERVER redshift
+OPTIONS (schema_name 'public', table_name 'audit');
+
+-- Step 6: Verify access
+-- Run these to confirm the foreign tables are accessible:
+
+-- SELECT count(*) FROM redshift_fdw.chronicle_usage_events LIMIT 1;
+-- SELECT count(*) FROM redshift_fdw.chronicle_usage_stats LIMIT 1;
+-- SELECT count(*) FROM redshift_fdw.sensor_data LIMIT 1;
+-- SELECT count(*) FROM redshift_fdw.audit LIMIT 1;
+
+-- Step 7: Tune for large migrations (optional)
+-- Increase fetch_size for better throughput on large scans:
+-- ALTER SERVER redshift OPTIONS (SET fetch_size '50000');
+--
+-- If you hit timeouts on large batches:
+-- ALTER SERVER redshift OPTIONS (ADD connect_timeout '30');

--- a/src/main/resources/redshift_to_aurora_migration.sql
+++ b/src/main/resources/redshift_to_aurora_migration.sql
@@ -1,0 +1,498 @@
+-- ============================================================================
+-- Redshift to Aurora (Postgres) Migration via Foreign Data Wrapper
+-- ============================================================================
+-- Prerequisites:
+--   1. postgres_fdw extension installed and foreign tables set up (see redshift_fdw_setup.sql)
+--   2. dedup_hash columns added to target tables (see ALTER TABLE statements below)
+--
+-- Uses Postgres built-in hashtextextended(text, bigint) with two seeds (0, 1)
+-- to produce a 128-bit salted hash for dedup. No extensions required beyond postgres_fdw.
+--
+-- Run these statements in order. Adjust foreign schema name, batch sizes,
+-- and timestamp ranges as needed. Safe to re-run (idempotent).
+-- ============================================================================
+
+-- Step 0: Create event tables on Aurora
+-- These tables previously only existed on Redshift. Create them on Aurora with
+-- dedup_hash columns and unique index included from the start.
+-- IF NOT EXISTS makes this safe to re-run.
+
+CREATE TABLE IF NOT EXISTS chronicle_usage_events (
+    study_id            varchar(36) NOT NULL,
+    participant_id      text NOT NULL,
+    app_package_name    text,
+    interaction_type    text,
+    event_type          integer,
+    event_timestamp     timestamptz,
+    timezone            text,
+    username            text,
+    application_label   text,
+    uploaded_at         timestamptz DEFAULT now(),
+    dedup_hash_0        bigint NOT NULL DEFAULT 0,
+    dedup_hash_1        bigint NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS chronicle_usage_stats (
+    study_id            varchar(36) NOT NULL,
+    participant_id      text NOT NULL,
+    app_package_name    text,
+    interaction_type    text,
+    start_time          timestamptz,
+    end_time            timestamptz,
+    duration            bigint,
+    event_timestamp     timestamptz,
+    timezone            text,
+    application_label   text,
+    dedup_hash_0        bigint NOT NULL DEFAULT 0,
+    dedup_hash_1        bigint NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS sensor_data (
+    -- shared sensor columns
+    study_id            varchar(36) NOT NULL,
+    participant_id      text NOT NULL,
+    sample_id           varchar(36) NOT NULL,
+    sensor_type         text NOT NULL,
+    sample_duration     double precision NOT NULL,
+    recordeddate        timestamptz,
+    datetimestart       timestamptz,
+    datetimeend         timestamptz,
+    timezone            text,
+    device_version      text NOT NULL,
+    device_name         text NOT NULL,
+    device_model        text NOT NULL,
+    device_system_name  text NOT NULL,
+    -- device usage
+    total_screen_wakes  integer,
+    total_unlock_duration double precision,
+    total_unlocks       integer,
+    app_category        text,
+    app_usage_time      double precision,
+    text_input_source   text,
+    text_input_duration double precision,
+    bundle_identifier   text,
+    app_category_web_duration double precision,
+    -- phone usage
+    total_incoming_calls integer,
+    total_outgoing_calls integer,
+    total_call_duration double precision,
+    total_unique_contacts integer,
+    -- messages usage
+    total_incoming_messages integer,
+    total_outgoing_messages integer,
+    -- keyboard metrics
+    total_words         integer,
+    total_altered_words integer,
+    total_taps          integer,
+    total_drags         integer,
+    total_deletes       integer,
+    total_emojis        integer,
+    total_paths         integer,
+    total_path_time     double precision,
+    total_path_length   double precision,
+    total_autocorrections integer,
+    total_space_corrections integer,
+    total_transposition_corrections integer,
+    insert_key_corrections integer,
+    total_retro_corrections integer,
+    total_skip_touch_corrections integer,
+    total_near_key_corrections integer,
+    total_substitution_corrections integer,
+    total_test_hit_corrections integer,
+    total_typing_duration double precision,
+    total_path_pauses   integer,
+    total_pauses        integer,
+    total_typing_episodes integer,
+    sentiment           text,
+    sentiment_word_count integer,
+    sentiment_emoji_count integer,
+    typing_speed        double precision,
+    path_typing_speed   double precision,
+    -- utility
+    exact_recordeddate  timestamptz,
+    -- dedup
+    dedup_hash_0        bigint NOT NULL DEFAULT 0,
+    dedup_hash_1        bigint NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS audit (
+    acl_key             varchar(256) NOT NULL,
+    id                  varchar(36) NOT NULL,
+    principal_type      varchar(128) NOT NULL,
+    principal_id        varchar(256) NOT NULL,
+    audit_event_type    varchar(256) NOT NULL,
+    study_id            varchar(36) NOT NULL,
+    organization_id     varchar(36) NOT NULL,
+    description         varchar(256) NOT NULL,
+    data                varchar(65535) NOT NULL,
+    event_timestamp     timestamptz
+);
+
+-- Step 1: Add dedup hash columns to existing tables (no-op if Step 0 already created them)
+-- Column additions are instant (metadata-only) in Postgres 11+ with a non-volatile default.
+-- Safe to run while the server is active — existing queries use explicit column lists.
+-- DO NOT create indexes here — all rows default to (0,0) which violates uniqueness.
+-- Indexes are created in Step 2b AFTER backfilling hashes.
+
+ALTER TABLE chronicle_usage_events ADD COLUMN IF NOT EXISTS dedup_hash_0 bigint NOT NULL DEFAULT 0;
+ALTER TABLE chronicle_usage_events ADD COLUMN IF NOT EXISTS dedup_hash_1 bigint NOT NULL DEFAULT 0;
+
+ALTER TABLE chronicle_usage_stats ADD COLUMN IF NOT EXISTS dedup_hash_0 bigint NOT NULL DEFAULT 0;
+ALTER TABLE chronicle_usage_stats ADD COLUMN IF NOT EXISTS dedup_hash_1 bigint NOT NULL DEFAULT 0;
+
+ALTER TABLE sensor_data ADD COLUMN IF NOT EXISTS dedup_hash_0 bigint NOT NULL DEFAULT 0;
+ALTER TABLE sensor_data ADD COLUMN IF NOT EXISTS dedup_hash_1 bigint NOT NULL DEFAULT 0;
+
+-- Step 2: Backfill dedup hashes for any existing rows in Aurora
+-- (These may take a while on large tables; consider batching with WHERE clauses)
+
+UPDATE chronicle_usage_events
+SET dedup_hash_0 = hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, app_package_name::text,
+        interaction_type::text, event_type::text, event_timestamp::text,
+        timezone::text, username::text, application_label::text
+    ), 0),
+    dedup_hash_1 = hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, app_package_name::text,
+        interaction_type::text, event_type::text, event_timestamp::text,
+        timezone::text, username::text, application_label::text
+    ), 1)
+WHERE dedup_hash_0 = 0 AND dedup_hash_1 = 0;
+
+UPDATE sensor_data
+SET dedup_hash_0 = hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, sensor_type::text,
+        sample_duration::text, recordeddate::text, timezone::text,
+        device_version::text, device_name::text, device_model::text,
+        device_system_name::text,
+        total_screen_wakes::text, total_unlock_duration::text, total_unlocks::text,
+        app_category::text, app_usage_time::text, text_input_source::text,
+        text_input_duration::text, bundle_identifier::text, app_category_web_duration::text,
+        total_incoming_calls::text, total_outgoing_calls::text, total_call_duration::text,
+        total_unique_contacts::text,
+        total_incoming_messages::text, total_outgoing_messages::text,
+        total_words::text, total_altered_words::text, total_taps::text,
+        total_drags::text, total_deletes::text, total_emojis::text,
+        total_paths::text, total_path_time::text, total_path_length::text,
+        total_autocorrections::text, total_space_corrections::text,
+        total_transposition_corrections::text, insert_key_corrections::text,
+        total_retro_corrections::text, total_skip_touch_corrections::text,
+        total_near_key_corrections::text, total_substitution_corrections::text,
+        total_test_hit_corrections::text, total_typing_duration::text,
+        total_path_pauses::text, total_pauses::text, total_typing_episodes::text,
+        sentiment::text, sentiment_word_count::text, sentiment_emoji_count::text,
+        typing_speed::text, path_typing_speed::text
+    ), 0),
+    dedup_hash_1 = hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, sensor_type::text,
+        sample_duration::text, recordeddate::text, timezone::text,
+        device_version::text, device_name::text, device_model::text,
+        device_system_name::text,
+        total_screen_wakes::text, total_unlock_duration::text, total_unlocks::text,
+        app_category::text, app_usage_time::text, text_input_source::text,
+        text_input_duration::text, bundle_identifier::text, app_category_web_duration::text,
+        total_incoming_calls::text, total_outgoing_calls::text, total_call_duration::text,
+        total_unique_contacts::text,
+        total_incoming_messages::text, total_outgoing_messages::text,
+        total_words::text, total_altered_words::text, total_taps::text,
+        total_drags::text, total_deletes::text, total_emojis::text,
+        total_paths::text, total_path_time::text, total_path_length::text,
+        total_autocorrections::text, total_space_corrections::text,
+        total_transposition_corrections::text, insert_key_corrections::text,
+        total_retro_corrections::text, total_skip_touch_corrections::text,
+        total_near_key_corrections::text, total_substitution_corrections::text,
+        total_test_hit_corrections::text, total_typing_duration::text,
+        total_path_pauses::text, total_pauses::text, total_typing_episodes::text,
+        sentiment::text, sentiment_word_count::text, sentiment_emoji_count::text,
+        typing_speed::text, path_typing_speed::text
+    ), 1)
+WHERE dedup_hash_0 = 0 AND dedup_hash_1 = 0;
+
+-- Step 2b: Create unique indexes AFTER backfill
+-- Uses CONCURRENTLY to avoid locking tables while the running server is active.
+-- NOTE: CONCURRENTLY cannot run inside a transaction block — run each statement individually.
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS chronicle_usage_events_dedup_idx ON chronicle_usage_events (dedup_hash_0, dedup_hash_1);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS chronicle_usage_stats_dedup_idx ON chronicle_usage_stats (dedup_hash_0, dedup_hash_1);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS sensor_data_dedup_idx ON sensor_data (dedup_hash_0, dedup_hash_1);
+
+-- Step 3: Migrate chronicle_usage_events
+-- Run in batches by timestamp range. Adjust date range as needed.
+-- ROW_NUMBER deduplicates at source, taking the latest upload per unique event.
+
+WITH ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY study_id, participant_id, app_package_name, interaction_type,
+                         event_type, event_timestamp, timezone, username, application_label
+            ORDER BY uploaded_at DESC NULLS LAST
+        ) as rn
+    FROM redshift_fdw.chronicle_usage_events
+    WHERE event_timestamp >= '2020-01-01'::timestamptz
+      AND event_timestamp <  '2020-02-01'::timestamptz
+)
+INSERT INTO chronicle_usage_events (
+    study_id, participant_id, app_package_name, interaction_type, event_type,
+    event_timestamp, timezone, username, application_label, uploaded_at,
+    dedup_hash_0, dedup_hash_1
+)
+SELECT
+    study_id, participant_id, app_package_name, interaction_type, event_type,
+    event_timestamp, timezone, username, application_label, uploaded_at,
+    hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, app_package_name::text,
+        interaction_type::text, event_type::text, event_timestamp::text,
+        timezone::text, username::text, application_label::text
+    ), 0),
+    hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, app_package_name::text,
+        interaction_type::text, event_type::text, event_timestamp::text,
+        timezone::text, username::text, application_label::text
+    ), 1)
+FROM ranked
+WHERE rn = 1
+ON CONFLICT (dedup_hash_0, dedup_hash_1) DO UPDATE SET uploaded_at = EXCLUDED.uploaded_at
+WHERE chronicle_usage_events.study_id IS NOT DISTINCT FROM EXCLUDED.study_id
+  AND chronicle_usage_events.participant_id IS NOT DISTINCT FROM EXCLUDED.participant_id
+  AND chronicle_usage_events.app_package_name IS NOT DISTINCT FROM EXCLUDED.app_package_name
+  AND chronicle_usage_events.interaction_type IS NOT DISTINCT FROM EXCLUDED.interaction_type
+  AND chronicle_usage_events.event_type IS NOT DISTINCT FROM EXCLUDED.event_type
+  AND chronicle_usage_events.event_timestamp IS NOT DISTINCT FROM EXCLUDED.event_timestamp
+  AND chronicle_usage_events.timezone IS NOT DISTINCT FROM EXCLUDED.timezone
+  AND chronicle_usage_events.username IS NOT DISTINCT FROM EXCLUDED.username
+  AND chronicle_usage_events.application_label IS NOT DISTINCT FROM EXCLUDED.application_label;
+
+-- Step 4: Migrate chronicle_usage_stats
+
+WITH ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY study_id, participant_id, app_package_name, interaction_type,
+                         start_time, end_time, duration, event_timestamp, timezone, application_label
+            ORDER BY event_timestamp DESC NULLS LAST
+        ) as rn
+    FROM redshift_fdw.chronicle_usage_stats
+    WHERE event_timestamp >= '2020-01-01'::timestamptz
+      AND event_timestamp <  '2020-02-01'::timestamptz
+)
+INSERT INTO chronicle_usage_stats (
+    study_id, participant_id, app_package_name, interaction_type,
+    start_time, end_time, duration, event_timestamp, timezone, application_label,
+    dedup_hash_0, dedup_hash_1
+)
+SELECT
+    study_id, participant_id, app_package_name, interaction_type,
+    start_time, end_time, duration, event_timestamp, timezone, application_label,
+    hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, app_package_name::text,
+        interaction_type::text, start_time::text, end_time::text,
+        duration::text, event_timestamp::text, timezone::text, application_label::text
+    ), 0),
+    hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, app_package_name::text,
+        interaction_type::text, start_time::text, end_time::text,
+        duration::text, event_timestamp::text, timezone::text, application_label::text
+    ), 1)
+FROM ranked
+WHERE rn = 1
+ON CONFLICT (dedup_hash_0, dedup_hash_1) DO NOTHING;
+
+-- Step 5: Migrate sensor_data (iOS)
+-- ROW_NUMBER deduplicates at source, taking latest recording per unique sensor sample.
+
+WITH ranked AS (
+    SELECT *,
+        ROW_NUMBER() OVER (
+            PARTITION BY study_id, participant_id, sensor_type, sample_duration,
+                         recordeddate, timezone,
+                         device_version, device_name, device_model, device_system_name,
+                         total_screen_wakes, total_unlock_duration, total_unlocks,
+                         app_category, app_usage_time, text_input_source, text_input_duration,
+                         bundle_identifier, app_category_web_duration,
+                         total_incoming_calls, total_outgoing_calls, total_call_duration, total_unique_contacts,
+                         total_incoming_messages, total_outgoing_messages,
+                         total_words, total_altered_words, total_taps, total_drags, total_deletes,
+                         total_emojis, total_paths, total_path_time, total_path_length,
+                         total_autocorrections, total_space_corrections, total_transposition_corrections,
+                         insert_key_corrections, total_retro_corrections, total_skip_touch_corrections,
+                         total_near_key_corrections, total_substitution_corrections, total_test_hit_corrections,
+                         total_typing_duration, total_path_pauses, total_pauses, total_typing_episodes,
+                         sentiment, sentiment_word_count, sentiment_emoji_count,
+                         typing_speed, path_typing_speed
+            ORDER BY exact_recordeddate DESC NULLS LAST
+        ) as rn
+    FROM redshift_fdw.sensor_data
+    WHERE recordeddate >= '2020-01-01'::timestamptz
+      AND recordeddate <  '2020-02-01'::timestamptz
+)
+INSERT INTO sensor_data (
+    study_id, participant_id, sample_id, sensor_type, sample_duration,
+    recordeddate, datetimestart, datetimeend, timezone,
+    device_version, device_name, device_model, device_system_name,
+    total_screen_wakes, total_unlock_duration, total_unlocks,
+    app_category, app_usage_time, text_input_source, text_input_duration,
+    bundle_identifier, app_category_web_duration,
+    total_incoming_calls, total_outgoing_calls, total_call_duration, total_unique_contacts,
+    total_incoming_messages, total_outgoing_messages,
+    total_words, total_altered_words, total_taps, total_drags, total_deletes,
+    total_emojis, total_paths, total_path_time, total_path_length,
+    total_autocorrections, total_space_corrections, total_transposition_corrections,
+    insert_key_corrections, total_retro_corrections, total_skip_touch_corrections,
+    total_near_key_corrections, total_substitution_corrections, total_test_hit_corrections,
+    total_typing_duration, total_path_pauses, total_pauses, total_typing_episodes,
+    sentiment, sentiment_word_count, sentiment_emoji_count,
+    typing_speed, path_typing_speed,
+    exact_recordeddate,
+    dedup_hash_0, dedup_hash_1
+)
+SELECT
+    study_id, participant_id, sample_id, sensor_type, sample_duration,
+    recordeddate, datetimestart, datetimeend, timezone,
+    device_version, device_name, device_model, device_system_name,
+    total_screen_wakes, total_unlock_duration, total_unlocks,
+    app_category, app_usage_time, text_input_source, text_input_duration,
+    bundle_identifier, app_category_web_duration,
+    total_incoming_calls, total_outgoing_calls, total_call_duration, total_unique_contacts,
+    total_incoming_messages, total_outgoing_messages,
+    total_words, total_altered_words, total_taps, total_drags, total_deletes,
+    total_emojis, total_paths, total_path_time, total_path_length,
+    total_autocorrections, total_space_corrections, total_transposition_corrections,
+    insert_key_corrections, total_retro_corrections, total_skip_touch_corrections,
+    total_near_key_corrections, total_substitution_corrections, total_test_hit_corrections,
+    total_typing_duration, total_path_pauses, total_pauses, total_typing_episodes,
+    sentiment, sentiment_word_count, sentiment_emoji_count,
+    typing_speed, path_typing_speed,
+    exact_recordeddate,
+    hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, sensor_type::text,
+        sample_duration::text, recordeddate::text, timezone::text,
+        device_version::text, device_name::text, device_model::text,
+        device_system_name::text,
+        total_screen_wakes::text, total_unlock_duration::text, total_unlocks::text,
+        app_category::text, app_usage_time::text, text_input_source::text,
+        text_input_duration::text, bundle_identifier::text, app_category_web_duration::text,
+        total_incoming_calls::text, total_outgoing_calls::text, total_call_duration::text,
+        total_unique_contacts::text,
+        total_incoming_messages::text, total_outgoing_messages::text,
+        total_words::text, total_altered_words::text, total_taps::text,
+        total_drags::text, total_deletes::text, total_emojis::text,
+        total_paths::text, total_path_time::text, total_path_length::text,
+        total_autocorrections::text, total_space_corrections::text,
+        total_transposition_corrections::text, insert_key_corrections::text,
+        total_retro_corrections::text, total_skip_touch_corrections::text,
+        total_near_key_corrections::text, total_substitution_corrections::text,
+        total_test_hit_corrections::text, total_typing_duration::text,
+        total_path_pauses::text, total_pauses::text, total_typing_episodes::text,
+        sentiment::text, sentiment_word_count::text, sentiment_emoji_count::text,
+        typing_speed::text, path_typing_speed::text
+    ), 0),
+    hashtextextended(concat_ws(chr(31),
+        study_id::text, participant_id::text, sensor_type::text,
+        sample_duration::text, recordeddate::text, timezone::text,
+        device_version::text, device_name::text, device_model::text,
+        device_system_name::text,
+        total_screen_wakes::text, total_unlock_duration::text, total_unlocks::text,
+        app_category::text, app_usage_time::text, text_input_source::text,
+        text_input_duration::text, bundle_identifier::text, app_category_web_duration::text,
+        total_incoming_calls::text, total_outgoing_calls::text, total_call_duration::text,
+        total_unique_contacts::text,
+        total_incoming_messages::text, total_outgoing_messages::text,
+        total_words::text, total_altered_words::text, total_taps::text,
+        total_drags::text, total_deletes::text, total_emojis::text,
+        total_paths::text, total_path_time::text, total_path_length::text,
+        total_autocorrections::text, total_space_corrections::text,
+        total_transposition_corrections::text, insert_key_corrections::text,
+        total_retro_corrections::text, total_skip_touch_corrections::text,
+        total_near_key_corrections::text, total_substitution_corrections::text,
+        total_test_hit_corrections::text, total_typing_duration::text,
+        total_path_pauses::text, total_pauses::text, total_typing_episodes::text,
+        sentiment::text, sentiment_word_count::text, sentiment_emoji_count::text,
+        typing_speed::text, path_typing_speed::text
+    ), 1)
+FROM ranked
+WHERE rn = 1
+ON CONFLICT (dedup_hash_0, dedup_hash_1) DO UPDATE SET
+    sample_id = LEAST(sensor_data.sample_id, EXCLUDED.sample_id),
+    datetimestart = LEAST(sensor_data.datetimestart, EXCLUDED.datetimestart),
+    datetimeend = GREATEST(sensor_data.datetimeend, EXCLUDED.datetimeend),
+    exact_recordeddate = LEAST(sensor_data.exact_recordeddate, EXCLUDED.exact_recordeddate)
+WHERE sensor_data.study_id IS NOT DISTINCT FROM EXCLUDED.study_id
+  AND sensor_data.participant_id IS NOT DISTINCT FROM EXCLUDED.participant_id
+  AND sensor_data.sensor_type IS NOT DISTINCT FROM EXCLUDED.sensor_type
+  AND sensor_data.sample_duration IS NOT DISTINCT FROM EXCLUDED.sample_duration
+  AND sensor_data.recordeddate IS NOT DISTINCT FROM EXCLUDED.recordeddate
+  AND sensor_data.timezone IS NOT DISTINCT FROM EXCLUDED.timezone
+  AND sensor_data.device_version IS NOT DISTINCT FROM EXCLUDED.device_version
+  AND sensor_data.device_name IS NOT DISTINCT FROM EXCLUDED.device_name
+  AND sensor_data.device_model IS NOT DISTINCT FROM EXCLUDED.device_model
+  AND sensor_data.device_system_name IS NOT DISTINCT FROM EXCLUDED.device_system_name
+  AND sensor_data.total_screen_wakes IS NOT DISTINCT FROM EXCLUDED.total_screen_wakes
+  AND sensor_data.total_unlock_duration IS NOT DISTINCT FROM EXCLUDED.total_unlock_duration
+  AND sensor_data.total_unlocks IS NOT DISTINCT FROM EXCLUDED.total_unlocks
+  AND sensor_data.app_category IS NOT DISTINCT FROM EXCLUDED.app_category
+  AND sensor_data.app_usage_time IS NOT DISTINCT FROM EXCLUDED.app_usage_time
+  AND sensor_data.text_input_source IS NOT DISTINCT FROM EXCLUDED.text_input_source
+  AND sensor_data.text_input_duration IS NOT DISTINCT FROM EXCLUDED.text_input_duration
+  AND sensor_data.bundle_identifier IS NOT DISTINCT FROM EXCLUDED.bundle_identifier
+  AND sensor_data.app_category_web_duration IS NOT DISTINCT FROM EXCLUDED.app_category_web_duration
+  AND sensor_data.total_incoming_calls IS NOT DISTINCT FROM EXCLUDED.total_incoming_calls
+  AND sensor_data.total_outgoing_calls IS NOT DISTINCT FROM EXCLUDED.total_outgoing_calls
+  AND sensor_data.total_call_duration IS NOT DISTINCT FROM EXCLUDED.total_call_duration
+  AND sensor_data.total_unique_contacts IS NOT DISTINCT FROM EXCLUDED.total_unique_contacts
+  AND sensor_data.total_incoming_messages IS NOT DISTINCT FROM EXCLUDED.total_incoming_messages
+  AND sensor_data.total_outgoing_messages IS NOT DISTINCT FROM EXCLUDED.total_outgoing_messages
+  AND sensor_data.total_words IS NOT DISTINCT FROM EXCLUDED.total_words
+  AND sensor_data.total_altered_words IS NOT DISTINCT FROM EXCLUDED.total_altered_words
+  AND sensor_data.total_taps IS NOT DISTINCT FROM EXCLUDED.total_taps
+  AND sensor_data.total_drags IS NOT DISTINCT FROM EXCLUDED.total_drags
+  AND sensor_data.total_deletes IS NOT DISTINCT FROM EXCLUDED.total_deletes
+  AND sensor_data.total_emojis IS NOT DISTINCT FROM EXCLUDED.total_emojis
+  AND sensor_data.total_paths IS NOT DISTINCT FROM EXCLUDED.total_paths
+  AND sensor_data.total_path_time IS NOT DISTINCT FROM EXCLUDED.total_path_time
+  AND sensor_data.total_path_length IS NOT DISTINCT FROM EXCLUDED.total_path_length
+  AND sensor_data.total_autocorrections IS NOT DISTINCT FROM EXCLUDED.total_autocorrections
+  AND sensor_data.total_space_corrections IS NOT DISTINCT FROM EXCLUDED.total_space_corrections
+  AND sensor_data.total_transposition_corrections IS NOT DISTINCT FROM EXCLUDED.total_transposition_corrections
+  AND sensor_data.insert_key_corrections IS NOT DISTINCT FROM EXCLUDED.insert_key_corrections
+  AND sensor_data.total_retro_corrections IS NOT DISTINCT FROM EXCLUDED.total_retro_corrections
+  AND sensor_data.total_skip_touch_corrections IS NOT DISTINCT FROM EXCLUDED.total_skip_touch_corrections
+  AND sensor_data.total_near_key_corrections IS NOT DISTINCT FROM EXCLUDED.total_near_key_corrections
+  AND sensor_data.total_substitution_corrections IS NOT DISTINCT FROM EXCLUDED.total_substitution_corrections
+  AND sensor_data.total_test_hit_corrections IS NOT DISTINCT FROM EXCLUDED.total_test_hit_corrections
+  AND sensor_data.total_typing_duration IS NOT DISTINCT FROM EXCLUDED.total_typing_duration
+  AND sensor_data.total_path_pauses IS NOT DISTINCT FROM EXCLUDED.total_path_pauses
+  AND sensor_data.total_pauses IS NOT DISTINCT FROM EXCLUDED.total_pauses
+  AND sensor_data.total_typing_episodes IS NOT DISTINCT FROM EXCLUDED.total_typing_episodes
+  AND sensor_data.sentiment IS NOT DISTINCT FROM EXCLUDED.sentiment
+  AND sensor_data.sentiment_word_count IS NOT DISTINCT FROM EXCLUDED.sentiment_word_count
+  AND sensor_data.sentiment_emoji_count IS NOT DISTINCT FROM EXCLUDED.sentiment_emoji_count
+  AND sensor_data.typing_speed IS NOT DISTINCT FROM EXCLUDED.typing_speed
+  AND sensor_data.path_typing_speed IS NOT DISTINCT FROM EXCLUDED.path_typing_speed;
+
+-- Step 6: Migrate audit events (append-only, no dedup)
+INSERT INTO audit (
+    acl_key, id, principal_type, principal_id, audit_event_type,
+    study_id, organization_id, description, data, event_timestamp
+)
+SELECT
+    acl_key, id, principal_type, principal_id, audit_event_type,
+    study_id, organization_id, description, data, event_timestamp
+FROM redshift_fdw.audit
+WHERE event_timestamp >= '2020-01-01'::timestamptz
+  AND event_timestamp <  '2020-02-01'::timestamptz
+ON CONFLICT DO NOTHING;
+
+-- Step 7: Verification queries
+-- Compare row counts between Redshift (via FDW) and Aurora:
+
+-- SELECT 'redshift' as source, count(*) FROM redshift_fdw.chronicle_usage_events
+-- UNION ALL
+-- SELECT 'aurora' as source, count(*) FROM chronicle_usage_events;
+
+-- SELECT 'redshift' as source, count(*) FROM redshift_fdw.sensor_data
+-- UNION ALL
+-- SELECT 'aurora' as source, count(*) FROM sensor_data;
+
+-- SELECT 'redshift' as source, count(*) FROM redshift_fdw.chronicle_usage_stats
+-- UNION ALL
+-- SELECT 'aurora' as source, count(*) FROM chronicle_usage_stats;


### PR DESCRIPTION
Redshift is too expensive we can handle then load on a single aurora instance. Also upgrades to AWS v2 SDK.