### PR TITLE
Participant Task once a month, switch to union on insert data

### DIFF
--- a/src/main/kotlin/com/openlattice/chronicle/mapstores/stats/ParticipantStatsMapstore.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/mapstores/stats/ParticipantStatsMapstore.kt
@@ -1,7 +1,9 @@
 package com.openlattice.chronicle.mapstores.stats
 
 import com.geekbeast.postgres.PostgresArrays
+import com.geekbeast.postgres.PostgresColumnDefinition
 import com.geekbeast.postgres.mapstores.AbstractBasePostgresMapstore
+import com.google.common.collect.ImmutableList
 import com.hazelcast.config.EvictionConfig
 import com.hazelcast.config.MapConfig
 import com.hazelcast.config.MapStoreConfig
@@ -9,6 +11,9 @@ import com.openlattice.chronicle.hazelcast.HazelcastMap
 import com.openlattice.chronicle.participants.ParticipantStats
 import com.openlattice.chronicle.postgres.ResultSetAdapters
 import com.openlattice.chronicle.storage.ChroniclePostgresTables.Companion.PARTICIPANT_STATS
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.ANDROID_UNIQUE_DATES
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.IOS_UNIQUE_DATES
+import com.openlattice.chronicle.storage.PostgresColumns.Companion.TUD_UNIQUE_DATES
 import com.openlattice.chronicle.util.tests.TestDataFactory
 import com.zaxxer.hikari.HikariDataSource
 import org.apache.commons.lang3.RandomStringUtils
@@ -37,21 +42,18 @@ class ParticipantStatsMapstore(hds: HikariDataSource) : AbstractBasePostgresMaps
         return super.getMapConfig()
     }
 
+    /**
+     * The unique-dates arrays must merge via set-union on conflict so concurrent writes from
+     * ingestion-time mergers and the periodic reconciliation SQL can't clobber each other's dates.
+     */
+    override fun initUnionColumns(): List<PostgresColumnDefinition> {
+        return ImmutableList.of(ANDROID_UNIQUE_DATES, IOS_UNIQUE_DATES, TUD_UNIQUE_DATES)
+    }
+
     override fun bind(ps: PreparedStatement, key: ParticipantKey, value: ParticipantStats) {
         var offset = bind(ps, key)
-//        PostgresColumns.STUDY_ID,
-//        PostgresColumns.PARTICIPANT_ID,
-//        PostgresColumns.ANDROID_LAST_PING,
-//        PostgresColumns.ANDROID_FIRST_DATE,
-//        PostgresColumns.ANDROID_LAST_DATE,
-//        PostgresColumns.ANDROID_UNIQUE_DATES,
-//        PostgresColumns.IOS_LAST_PING,
-//        PostgresColumns.IOS_FIRST_DATE,
-//        PostgresColumns.IOS_LAST_DATE,
-//        PostgresColumns.IOS_UNIQUE_DATES,
-//        PostgresColumns.TUD_FIRST_DATE,
-//        PostgresColumns.TUD_LAST_DATE,
-//        PostgresColumns.TUD_UNIQUE_DATES
+
+        // INSERT VALUES half — bind every value column.
         ps.setObject(offset++, value.androidLastPing)
         ps.setObject(offset++, value.androidFirstDate)
         ps.setObject(offset++, value.androidLastDate)
@@ -64,19 +66,16 @@ class ParticipantStatsMapstore(hds: HikariDataSource) : AbstractBasePostgresMaps
         ps.setObject(offset++, value.tudLastDate)
         ps.setArray(offset++, PostgresArrays.createDateArray(ps.connection, value.tudUniqueDates))
 
-        //For update query
+        // ON CONFLICT DO UPDATE SET half — skip the *_unique_dates columns (they're declared as
+        // unionColumns() so the SET clause merges via array set-union with no parameter binding).
         ps.setObject(offset++, value.androidLastPing)
         ps.setObject(offset++, value.androidFirstDate)
         ps.setObject(offset++, value.androidLastDate)
-        ps.setArray(offset++, PostgresArrays.createDateArray(ps.connection, value.androidUniqueDates))
         ps.setObject(offset++, value.iosLastPing)
         ps.setObject(offset++, value.iosFirstDate)
         ps.setObject(offset++, value.iosLastDate)
-        ps.setArray(offset++, PostgresArrays.createDateArray(ps.connection, value.iosUniqueDates))
         ps.setObject(offset++, value.tudFirstDate)
         ps.setObject(offset++, value.tudLastDate)
-        ps.setArray(offset++, PostgresArrays.createDateArray(ps.connection, value.tudUniqueDates))
-
     }
 
     override fun bind(ps: PreparedStatement, key: ParticipantKey, offset: Int): Int {

--- a/src/main/kotlin/com/openlattice/chronicle/postgres/ResultSetAdapters.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/postgres/ResultSetAdapters.kt
@@ -138,7 +138,6 @@ import com.openlattice.chronicle.storage.RedshiftColumns.Companion.TIMESTAMP
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.TIMEZONE
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.UPLOADED_AT
 import com.openlattice.chronicle.storage.RedshiftColumns.Companion.USERNAME
-import com.openlattice.chronicle.storage.RedshiftDataTables.Companion.UNIQUE_DATES
 import com.openlattice.chronicle.storage.tasks.SensorDataEntries
 import com.openlattice.chronicle.study.Study
 import com.openlattice.chronicle.study.StudyFeature
@@ -566,14 +565,6 @@ class ResultSetAdapters {
         @Throws(SQLException::class)
         fun participantKey(rs: ResultSet): ParticipantKey {
             return ParticipantKey(studyId(rs), rs.getString(PARTICIPANT_ID.name))
-        }
-
-        @Throws(SQLException::class)
-        fun uniqueDates(rs: ResultSet): Set<LocalDate> {
-            return rs
-                .getString(UNIQUE_DATES)
-                .split(",")
-                .mapTo(mutableSetOf<LocalDate>()) { LocalDate.parse(it) }
         }
 
         @Throws(SQLException::class)

--- a/src/main/kotlin/com/openlattice/chronicle/services/studies/StudyManager.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/studies/StudyManager.kt
@@ -31,6 +31,7 @@ interface StudyManager {
     fun getStudySettings(studyId: UUID): Map<StudySettingType, StudySetting>
     fun getStudySettings(studyIds: Collection<UUID>): Map<UUID, Map<StudySettingType, StudySetting>>
     fun insertOrUpdateParticipantStats(stats: ParticipantStats)
+    fun evictParticipantStatsCache()
     fun isNotificationsEnabled(studyId: UUID): Boolean
     fun isValidStudy(studyId: UUID): Boolean
     fun refreshStudyCache(studyIds: Set<UUID>)

--- a/src/main/kotlin/com/openlattice/chronicle/services/studies/StudyService.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/services/studies/StudyService.kt
@@ -748,6 +748,13 @@ class StudyService(
         val key = ParticipantKey(stats.studyId, stats.participantId)
 
         participantStats.executeOnKey(key, ParticipantStatsMerger(stats))
+    }
+
+    override fun evictParticipantStatsCache() {
+        // Mapstore upsert merges via array set-union (declared in unionColumns), so pending
+        // write-behind entries can no longer clobber reconciliation results — flush() is not
+        // needed. evictAll forces subsequent reads to load reconciled values from Postgres.
+        participantStats.evictAll()
 //        storageResolver.getPlatformStorage().connection.use { connection ->
 //            connection.prepareStatement(INSERT_OR_UPDATE_PARTICIPANT_STATS).use { ps ->
 //                val androidDatesArr =

--- a/src/main/kotlin/com/openlattice/chronicle/storage/PostgresDataTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/PostgresDataTables.kt
@@ -421,22 +421,50 @@ class PostgresDataTables {
             """.trimIndent()
         }
 
-        // ========== Postgres-compatible participant stats queries ==========
+        // ========== Participant stats reconciliation (30-day true-up) ==========
+        //
+        // Bounded scan of the last 30 days of events, aggregated to a per-(study, participant) set of
+        // local calendar dates. ON CONFLICT unions the new dates with whatever is already persisted
+        // so older history (and any dates added concurrently via the IMap mapstore) is preserved.
 
-        const val UNIQUE_DATES = RedshiftDataTables.UNIQUE_DATES
+        const val PARTICIPANT_STATS_RECONCILE_LOOKBACK_DAYS = 30
 
-        val participantStatsIosSql = """
-                SELECT ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}, string_agg(distinct (${RedshiftColumns.RECORDED_DATE_TIME.name} at time zone ${RedshiftColumns.TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+        private val PARTICIPANT_STATS_TABLE = ChroniclePostgresTables.PARTICIPANT_STATS.name
+        private val IOS_UNIQUE_DATES_COL = PostgresColumns.IOS_UNIQUE_DATES.name
+        private val ANDROID_UNIQUE_DATES_COL = PostgresColumns.ANDROID_UNIQUE_DATES.name
+
+        val reconcileIosParticipantStatsSql = """
+                INSERT INTO $PARTICIPANT_STATS_TABLE (${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}, $IOS_UNIQUE_DATES_COL)
+                SELECT ${RedshiftColumns.STUDY_ID.name},
+                       ${RedshiftColumns.PARTICIPANT_ID.name},
+                       array_agg(DISTINCT (${RedshiftColumns.RECORDED_DATE_TIME.name} AT TIME ZONE ${RedshiftColumns.TIMEZONE.name})::date)
                 FROM ${RedshiftDataTables.IOS_SENSOR_DATA.name}
-                WHERE ${RedshiftColumns.STUDY_ID.name} = ?
+                WHERE ${RedshiftColumns.RECORDED_DATE_TIME.name} >= now() - interval '$PARTICIPANT_STATS_RECONCILE_LOOKBACK_DAYS days'
+                  AND ${RedshiftColumns.TIMEZONE.name} IS NOT NULL
+                  AND ${RedshiftColumns.TIMEZONE.name} != ''
                 GROUP BY ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}
+                ON CONFLICT (${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}) DO UPDATE
+                SET $IOS_UNIQUE_DATES_COL = (
+                    SELECT array_agg(DISTINCT d)
+                    FROM unnest($PARTICIPANT_STATS_TABLE.$IOS_UNIQUE_DATES_COL || EXCLUDED.$IOS_UNIQUE_DATES_COL) d
+                )
             """.trimIndent()
 
-        val participantStatsAndroidSql = """
-                SELECT ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}, string_agg(distinct (${RedshiftColumns.TIMESTAMP.name} at time zone ${RedshiftColumns.TIMEZONE.name})::date::text, ',') as $UNIQUE_DATES
+        val reconcileAndroidParticipantStatsSql = """
+                INSERT INTO $PARTICIPANT_STATS_TABLE (${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}, $ANDROID_UNIQUE_DATES_COL)
+                SELECT ${RedshiftColumns.STUDY_ID.name},
+                       ${RedshiftColumns.PARTICIPANT_ID.name},
+                       array_agg(DISTINCT (${RedshiftColumns.TIMESTAMP.name} AT TIME ZONE ${RedshiftColumns.TIMEZONE.name})::date)
                 FROM ${RedshiftDataTables.CHRONICLE_USAGE_EVENTS.name}
-                WHERE ${RedshiftColumns.STUDY_ID.name} = ? AND timezone != ''
+                WHERE ${RedshiftColumns.TIMESTAMP.name} >= now() - interval '$PARTICIPANT_STATS_RECONCILE_LOOKBACK_DAYS days'
+                  AND ${RedshiftColumns.TIMEZONE.name} IS NOT NULL
+                  AND ${RedshiftColumns.TIMEZONE.name} != ''
                 GROUP BY ${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}
+                ON CONFLICT (${RedshiftColumns.STUDY_ID.name}, ${RedshiftColumns.PARTICIPANT_ID.name}) DO UPDATE
+                SET $ANDROID_UNIQUE_DATES_COL = (
+                    SELECT array_agg(DISTINCT d)
+                    FROM unnest($PARTICIPANT_STATS_TABLE.$ANDROID_UNIQUE_DATES_COL || EXCLUDED.$ANDROID_UNIQUE_DATES_COL) d
+                )
             """.trimIndent()
 
         // ========== Column Index Helpers ==========

--- a/src/main/kotlin/com/openlattice/chronicle/storage/RedshiftDataTables.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/RedshiftDataTables.kt
@@ -405,21 +405,6 @@ class RedshiftDataTables {
         val INSERT_USAGE_STATS_COLUMN_INDICES: Map<String, Int> =
             CHRONICLE_USAGE_STATS.columns.mapIndexed { index, pcd -> pcd.name to (index + 1) }.toMap()
 
-        const val UNIQUE_DATES = "unique_dates"
-        val participantStatsIosSql = """
-                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, listagg(distinct TRUNC(${RECORDED_DATE_TIME.name} at time zone ${TIMEZONE.name}), ',') as $UNIQUE_DATES
-                FROM ${IOS_SENSOR_DATA.name}
-                WHERE ${STUDY_ID.name} = ?
-                GROUP BY ${STUDY_ID.name}, ${PARTICIPANT_ID.name}
-            """.trimIndent()
-
-        val participantStatsAndroidSql = """
-                SELECT ${STUDY_ID.name}, ${PARTICIPANT_ID.name}, listagg(distinct TRUNC(${TIMESTAMP.name} at time zone ${TIMEZONE.name}), ',') as $UNIQUE_DATES
-                FROM ${CHRONICLE_USAGE_EVENTS.name}
-                WHERE ${STUDY_ID.name} = ? AND timezone != ''
-                GROUP BY ${STUDY_ID.name}, ${PARTICIPANT_ID.name}
-            """.trimIndent()
-
         fun getInsertUsageEventColumnIndex(
             column: PostgresColumnDefinition,
         ): Int = INSERT_USAGE_EVENT_COLUMN_INDICES.getValue(column.name)

--- a/src/main/kotlin/com/openlattice/chronicle/storage/tasks/RecalculateParticipantStatsTask.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/storage/tasks/RecalculateParticipantStatsTask.kt
@@ -1,137 +1,66 @@
 package com.openlattice.chronicle.storage.tasks
 
-import com.geekbeast.postgres.streams.BasePostgresIterable
-import com.geekbeast.postgres.streams.PreparedStatementHolderSupplier
+import com.geekbeast.configuration.postgres.PostgresFlavor
 import com.geekbeast.tasks.HazelcastFixedRateTask
 import com.geekbeast.tasks.Task
-import com.google.common.util.concurrent.ListeningExecutorService
-import com.google.common.util.concurrent.MoreExecutors
-import com.openlattice.chronicle.mapstores.stats.ParticipantKey
-import com.openlattice.chronicle.participants.ParticipantStats
-import com.openlattice.chronicle.postgres.ResultSetAdapters
-import com.openlattice.chronicle.services.studies.StudyManager
-import com.geekbeast.configuration.postgres.PostgresFlavor
 import com.openlattice.chronicle.storage.PostgresDataTables
-import com.openlattice.chronicle.storage.RedshiftColumns.Companion.PARTICIPANT_ID
-import com.openlattice.chronicle.storage.RedshiftColumns.Companion.STUDY_ID
-import com.openlattice.chronicle.storage.RedshiftDataTables
-import com.zaxxer.hikari.HikariDataSource
 import org.slf4j.LoggerFactory
-import java.security.InvalidParameterException
-import java.util.*
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 /**
+ * Monthly true-up of `participant_stats.{ios,android}_unique_dates`.
+ *
+ * Incremental updates happen at ingestion time (`AppDataUploadService.updateParticipantStats` for
+ * Android, `MoveToIosEventStorageTask.updateParticipantStats` for iOS) and flow through the
+ * `participantStats` IMap with a 5-second write-behind. This task exists to recover any dates that
+ * the incremental path missed (crashes, races, late uploads inside the lookback window).
+ *
+ * The previous 12-hour, per-study, full-history streaming scan was the dominant Aurora read load.
+ * This replacement is a single bounded SQL upsert per platform with `ON CONFLICT` set-union, so
+ * older dates and concurrently-merged dates are preserved.
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 class RecalculateParticipantStatsTask : HazelcastFixedRateTask<RecalculateParticipantStatsTaskDependencies> {
     companion object {
         private val logger = LoggerFactory.getLogger(RecalculateParticipantStatsTask::class.java)
-
-        private val executor: ListeningExecutorService =
-            MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1))
     }
 
-    override fun getInitialDelay(): Long = 0
-
-    override fun getPeriod(): Long = 12
-
-    override fun getTimeUnit(): TimeUnit = TimeUnit.HOURS
-
-    override fun runTask() {
-        val f = executor.submit {
-            recalculateParticipantStats()
-        }
-        try {
-            f.get(4, TimeUnit.HOURS)
-        } catch (timeoutException: TimeoutException) {
-            logger.error("Timed out after one hour when recalculating participant stats", timeoutException)
-            f.cancel(true)
-        } catch (ex: Exception) {
-            logger.error("Exception when recalculating participant stats.", ex)
-        }
-    }
-
+    override fun getInitialDelay(): Long = 1
+    override fun getPeriod(): Long = 30
+    override fun getTimeUnit(): TimeUnit = TimeUnit.DAYS
     override fun getName(): String = Task.RECALCULATE_PARTICIPANT_STATS.name
     override fun getDependenciesClass(): Class<out RecalculateParticipantStatsTaskDependencies> =
         RecalculateParticipantStatsTaskDependencies::class.java
 
-    private fun recalculateParticipantStats() {
-        logger.info("Starting recalculation of participant stats...")
-        with(getDependency()) {
-            val (flavor, events) = storageResolver.getDefaultEventStorage()
-            val studyIds = studyService.getAllStudyIds()
-            recalculateParticipantStats(studyService, studyIds, events, ParticipantStat.Ios, flavor)
-            recalculateParticipantStats(studyService, studyIds, events, ParticipantStat.Android, flavor)
-        }
-    }
+    override fun runTask() {
+        try {
+            with(getDependency()) {
+                val (flavor, _) = storageResolver.getDefaultEventStorage()
+                if (flavor == PostgresFlavor.REDSHIFT) {
+                    logger.warn("Skipping participant stats reconciliation: only supported on Postgres-flavor event storage.")
+                    return
+                }
 
-    private fun recalculateParticipantStats(
-        studyService: StudyManager,
-        studyIds: Iterable<UUID>,
-        hds: HikariDataSource,
-        statType: ParticipantStat,
-        flavor: PostgresFlavor
-    ) {
-        val sql = when (statType) {
-            ParticipantStat.Ios -> if (flavor == PostgresFlavor.REDSHIFT) RedshiftDataTables.participantStatsIosSql else PostgresDataTables.participantStatsIosSql
-            ParticipantStat.Android -> if (flavor == PostgresFlavor.REDSHIFT) RedshiftDataTables.participantStatsAndroidSql else PostgresDataTables.participantStatsAndroidSql
-            ParticipantStat.Tud -> throw InvalidParameterException("Not yet implemented for time use diary.")
-        }
-        studyIds.asSequence().forEach { studyId ->
-            logger.info("Recalculating participant stats for study $studyId")
-            BasePostgresIterable(
-                PreparedStatementHolderSupplier(
-                    hds,
-                    sql,
-                    fetchSize = 65536,
-                ) {
-                    when (flavor) {
-                        PostgresFlavor.REDSHIFT -> it.setString(1, studyId.toString())
-                        else -> it.setObject(1, studyId)
+                logger.info(
+                    "Starting {}-day participant stats reconciliation...",
+                    PostgresDataTables.PARTICIPANT_STATS_RECONCILE_LOOKBACK_DAYS
+                )
+
+                storageResolver.getPlatformStorage().connection.use { connection ->
+                    connection.createStatement().use { stmt ->
+                        val ios = stmt.executeUpdate(PostgresDataTables.reconcileIosParticipantStatsSql)
+                        logger.info("Reconciled iOS unique dates for {} (study, participant) rows.", ios)
+                        val android = stmt.executeUpdate(PostgresDataTables.reconcileAndroidParticipantStatsSql)
+                        logger.info("Reconciled Android unique dates for {} (study, participant) rows.", android)
                     }
                 }
-            ) {
-                ParticipantKey(
-                    UUID.fromString(it.getString(STUDY_ID.name)),
-                    it.getString(PARTICIPANT_ID.name)
-                ) to ResultSetAdapters.uniqueDates(it)
+
+                studyService.evictParticipantStatsCache()
+                logger.info("Completed participant stats reconciliation.")
             }
-                .toMap()
-                .forEach {
-                    studyService.insertOrUpdateParticipantStats(
-                        when (statType) {
-                            ParticipantStat.Ios -> ParticipantStats(
-                                studyId = it.key.studyId,
-                                participantId = it.key.participantId,
-                                iosUniqueDates = it.value
-                            )
-
-                            ParticipantStat.Android -> ParticipantStats(
-                                studyId = it.key.studyId,
-                                participantId = it.key.participantId,
-                                androidUniqueDates = it.value
-                            )
-//This one won't get used for a while.
-                            ParticipantStat.Tud -> ParticipantStats(
-                                studyId = it.key.studyId,
-                                participantId = it.key.participantId,
-                                tudUniqueDates = it.value
-                            )
-
-                        }
-                    )
-                }
-
+        } catch (ex: Exception) {
+            logger.error("Exception during participant stats reconciliation.", ex)
         }
     }
-}
-
-internal enum class ParticipantStat {
-    Android,
-    Ios,
-    Tud
 }


### PR DESCRIPTION
This fixes our excessive io bill in aurora from 1M iops every couple of hours from a full table scan.