### PR TITLE
Capture upload bodies and stop COMMITTED cascade on client disconnect

### DIFF
--- a/src/main/kotlin/com/openlattice/chronicle/controllers/ChronicleServerExceptionHandler.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/controllers/ChronicleServerExceptionHandler.kt
@@ -21,8 +21,10 @@ package com.openlattice.chronicle.controllers
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.geekbeast.controllers.exceptions.wrappers.ErrorsDTO
 import com.geekbeast.controllers.util.ApiExceptions
+import com.geekbeast.mappers.mappers.ObjectMappers
 import com.openlattice.chronicle.auditing.AuditEventType
 import com.openlattice.chronicle.auditing.AuditableEvent
 import com.openlattice.chronicle.auditing.AuditingComponent
@@ -30,21 +32,24 @@ import com.openlattice.chronicle.auditing.AuditingManager
 import com.openlattice.chronicle.authorization.AclKey
 import com.openlattice.chronicle.authorization.principals.Principals
 import com.openlattice.chronicle.ids.IdConstants
-import org.apache.commons.io.IOUtils
 import org.eclipse.jetty.io.EofException
 import org.slf4j.LoggerFactory
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.WebUtils
 import java.nio.charset.StandardCharsets
 import java.util.*
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -93,11 +98,8 @@ class ChronicleServerExceptionHandler @Inject constructor(override val auditingM
         } else ResponseEntity(HttpStatus.NOT_FOUND)
     }
 
-    @ExceptionHandler(IllegalArgumentException::class, HttpMessageNotReadableException::class)
+    @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(req: HttpServletRequest, e: Exception): ResponseEntity<ErrorsDTO> {
-        if (e is HttpMessageNotReadableException) {
-            logHttpMessageNotReadable(req, e)
-        }
         logException(req, e)
         return ResponseEntity(
             ErrorsDTO(ApiExceptions.ILLEGAL_ARGUMENT_EXCEPTION, e.message ?: e.javaClass.simpleName),
@@ -105,13 +107,51 @@ class ChronicleServerExceptionHandler @Inject constructor(override val auditingM
         )
     }
 
-    private fun logHttpMessageNotReadable(req: HttpServletRequest, e: HttpMessageNotReadableException) {
+    /**
+     * Handles failures to read/parse the request body. This is intentionally void-returning so that we own the
+     * response entirely: when the client has disconnected (EofException) or the response is already committed,
+     * attempting to serialize an error body throws while writing, which cascades into Spring's
+     * DefaultHandlerExceptionResolver calling sendError() on a committed response — the noisy
+     * "IllegalStateException: COMMITTED" we used to see. By writing nothing in that case we end the request cleanly.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadable(
+        req: HttpServletRequest,
+        res: HttpServletResponse,
+        e: HttpMessageNotReadableException,
+    ) {
+        val clientDisconnected = findCause(e, EofException::class.java) != null
+        logHttpMessageNotReadable(req, e, clientDisconnected)
+
+        if (clientDisconnected) {
+            // The socket is gone; there is no one to send a response to. Anything we write here would fail and
+            // trigger a secondary "COMMITTED" failure, so we stop quietly.
+            return
+        }
+
+        if (res.isCommitted) {
+            logger.warn("Response already committed while handling unreadable request body; not writing an error body.")
+            return
+        }
+
+        writeErrorResponse(res, e.message ?: e.javaClass.simpleName)
+    }
+
+    private fun logHttpMessageNotReadable(
+        req: HttpServletRequest,
+        e: HttpMessageNotReadableException,
+        clientDisconnected: Boolean,
+    ) {
         val jsonMappingException = findCause(e, JsonMappingException::class.java)
         val jsonProcessingException = findCause(e, JsonProcessingException::class.java)
-        val eofCause = findCause(e, EofException::class.java)
 
-        logger.error(
-            "HttpMessageNotReadable: method={} url={} contentLength={} contentType={} remoteAddr={} jacksonPath={} location={} clientDisconnected={}",
+        val cachedBody = cachedRequestBody(req)
+
+        // Client disconnects mid-upload are an expected condition on flaky mobile networks rather than a server
+        // bug, so log them at WARN to keep the error stream actionable; genuine malformed payloads stay at ERROR.
+        val message =
+            "HttpMessageNotReadable: method={} url={} contentLength={} contentType={} remoteAddr={} jacksonPath={} location={} clientDisconnected={} capturedBody={}"
+        val args = arrayOf<Any?>(
             req.method,
             req.requestURL,
             req.contentLengthLong,
@@ -119,23 +159,52 @@ class ChronicleServerExceptionHandler @Inject constructor(override val auditingM
             req.remoteAddr,
             jsonMappingException?.pathReference,
             jsonProcessingException?.location,
-            eofCause != null
+            clientDisconnected,
+            cachedBody ?: "<unavailable>"
         )
-
-        if (eofCause != null) {
-            logger.error("Client closed connection before sending complete request body; body is not available.")
-            return
+        if (clientDisconnected) {
+            logger.warn(message, *args)
+        } else {
+            logger.error(message, *args)
         }
 
+        if (cachedBody == null) {
+            logger.warn(
+                "No cached request body available for ${req.method} ${req.requestURL}; the body may have exceeded the cache limit, been empty, or the ContentCachingRequestFilter did not wrap this request."
+            )
+        }
+    }
+
+    /**
+     * Recovers the bytes that were actually received for this request from the [ContentCachingRequestWrapper]
+     * installed by ContentCachingRequestFilter. For a truncated upload this is the partial body up to the point the
+     * stream died. Returns null when no cached content is available.
+     */
+    private fun cachedRequestBody(req: HttpServletRequest): String? {
+        val wrapper = WebUtils.getNativeRequest(req, ContentCachingRequestWrapper::class.java) ?: return null
+        val bytes = wrapper.contentAsByteArray
+        if (bytes.isEmpty()) {
+            return null
+        }
+        val capped = if (bytes.size > MAX_LOGGED_BODY_BYTES) bytes.copyOf(MAX_LOGGED_BODY_BYTES) else bytes
+        val body = String(capped, StandardCharsets.UTF_8)
+        return if (bytes.size > MAX_LOGGED_BODY_BYTES || bytes.size.toLong() < req.contentLengthLong) {
+            "$body …[captured ${bytes.size} bytes of contentLength=${req.contentLengthLong}; truncated]"
+        } else {
+            body
+        }
+    }
+
+    private fun writeErrorResponse(res: HttpServletResponse, message: String) {
         try {
-            val body = IOUtils.toString(e.httpInputMessage.body, StandardCharsets.UTF_8)
-            if (body.isEmpty()) {
-                logger.error("Request body is empty or already consumed by the message converter; install a ContentCachingRequestWrapper filter to capture it after parsing fails.")
-            } else {
-                logger.error("Request body that caused error: {}", body)
-            }
+            res.status = HttpStatus.BAD_REQUEST.value()
+            res.contentType = MediaType.APPLICATION_JSON_VALUE
+            res.characterEncoding = StandardCharsets.UTF_8.name()
+            mapper.writeValue(res.outputStream, ErrorsDTO(ApiExceptions.ILLEGAL_ARGUMENT_EXCEPTION, message))
         } catch (ex: Exception) {
-            logger.error("Failed to re-read request body after message conversion failure: {}", ex.toString())
+            // Writing failed (e.g. the connection dropped between our committed check and the write). Nothing more
+            // we can do for the client; log and move on rather than letting this escalate.
+            logger.warn("Failed to write error response for unreadable request body: {}", ex.toString())
         }
     }
 
@@ -169,7 +238,12 @@ class ChronicleServerExceptionHandler @Inject constructor(override val auditingM
     
     @ExceptionHandler(JsonMappingException::class)
     fun handleJsonExceptions(req: HttpServletRequest, e: JsonMappingException) {
-        logger.error("Body that caused error if available: " + e.originalMessage)
+        logger.error(
+            "JsonMapping error: path={} originalMessage={} capturedBody={}",
+            e.pathReference,
+            e.originalMessage,
+            cachedRequestBody(req) ?: "<unavailable>"
+        )
         logException(req, e)
     }
 
@@ -190,6 +264,11 @@ class ChronicleServerExceptionHandler @Inject constructor(override val auditingM
 
     companion object {
         private val logger = LoggerFactory.getLogger(ChronicleServerExceptionHandler::class.java)
+        private val mapper: ObjectMapper = ObjectMappers.newJsonMapper()
+
+        // Cap how much of a captured body we emit to the logs to keep individual log lines bounded even though the
+        // request cache itself is already limited by ContentCachingRequestFilter.
+        private const val MAX_LOGGED_BODY_BYTES = 16 * 1024
     }
 }
 

--- a/src/main/kotlin/com/openlattice/chronicle/filters/ContentCachingRequestFilter.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/filters/ContentCachingRequestFilter.kt
@@ -1,0 +1,45 @@
+package com.openlattice.chronicle.filters
+
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Wraps requests that carry a body in a [ContentCachingRequestWrapper] so that, if downstream parsing fails (e.g. a
+ * malformed payload or a client that disconnects mid-upload), the exception handler can recover the bytes that were
+ * actually received and log them for investigation.
+ *
+ * The wrapper only retains bytes that are actually consumed by the downstream message converter, capped at
+ * [cacheLimit] to bound both heap usage and the size of anything we later write to the logs. For a truncated upload
+ * this yields the partial body up to the point the stream died, which is exactly what we want for debugging.
+ */
+class ContentCachingRequestFilter(private val cacheLimit: Int = DEFAULT_CACHE_LIMIT) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        // Only requests with a body can produce a parse failure worth capturing, and don't double-wrap.
+        if (hasBody(request) && request !is ContentCachingRequestWrapper) {
+            filterChain.doFilter(ContentCachingRequestWrapper(request, cacheLimit), response)
+        } else {
+            filterChain.doFilter(request, response)
+        }
+    }
+
+    private fun hasBody(request: HttpServletRequest): Boolean {
+        return when (request.method?.uppercase()) {
+            "POST", "PUT", "PATCH" -> true
+            else -> false
+        }
+    }
+
+    companion object {
+        // 256 KiB is enough to capture the leading portion of a sensor upload (hundreds of samples) while bounding
+        // heap per in-flight request and keeping log lines manageable.
+        const val DEFAULT_CACHE_LIMIT = 256 * 1024
+    }
+}

--- a/src/main/kotlin/com/openlattice/chronicle/pods/servlet/ChronicleServerSecurityPod.kt
+++ b/src/main/kotlin/com/openlattice/chronicle/pods/servlet/ChronicleServerSecurityPod.kt
@@ -30,6 +30,7 @@ import kotlin.Throws
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.web.filter.CharacterEncodingFilter
 import org.springframework.security.web.csrf.CsrfFilter
+import com.openlattice.chronicle.filters.ContentCachingRequestFilter
 import java.lang.Exception
 import java.nio.charset.StandardCharsets
 
@@ -69,5 +70,11 @@ class ChronicleServerSecurityPod : Auth0SecurityPod() {
         filter.encoding = StandardCharsets.UTF_8.toString()
         filter.setForceEncoding(true)
         http.addFilterBefore(filter, CsrfFilter::class.java)
+
+        // Cache request bodies so that, when a payload fails to parse (malformed JSON or a client that disconnects
+        // mid-upload), ChronicleServerExceptionHandler can recover and log the bytes that were actually received.
+        // Placed before the encoding filter so the wrapper is the request the rest of the chain (and the dispatcher's
+        // message converters) read from.
+        http.addFilterBefore(ContentCachingRequestFilter(), CharacterEncodingFilter::class.java)
     }
 }


### PR DESCRIPTION
## Problem

iOS sensor uploads (`POST /chronicle/v3/study/*/participant/*/ios/*`) that disconnect mid-stream produced two noisy, unactionable failures (observed 2026-06-21):

1. **`HttpMessageNotReadableException` (`EofException`)** — Jackson failed partway through the `List<SensorDataSample>` (`ArrayList[89]`). The handler detected the disconnect but logged *"body is not available"* because it tried to re-read the already-dead input stream.
2. **`IllegalStateException: COMMITTED`** — after the handler returned a `ResponseEntity`, Spring tried to serialize the error body to the dead socket. That write failed inside `ExceptionHandlerExceptionResolver`, which fell through to `DefaultHandlerExceptionResolver.sendError()` on an already-committed response.

The improved-logging handler from April was already deployed and still hit both, so this is a real fix, not just logging tweaks.

## Changes

- **New `ContentCachingRequestFilter`** — wraps POST/PUT/PATCH requests in a bounded (256 KiB) `ContentCachingRequestWrapper`, registered in `ChronicleServerSecurityPod` before the encoding filter so the dispatcher's message converters read through it. On a truncated upload it retains the partial body up to where the stream died — i.e. *the body that caused the issue*.
- **Dedicated void-returning `HttpMessageNotReadableException` handler** that owns the response: when the client disconnected (`EofException`) or the response is already committed, it writes nothing — eliminating the secondary write that caused `COMMITTED`. Otherwise it serializes the `ErrorsDTO` 400 itself.
- **Body capture in logs** — recovers and logs the captured body (truncated to 16 KiB) for both `HttpMessageNotReadableException` and `JsonMappingException`, alongside Jackson path/location and request context. Client disconnects log at **WARN** (expected on flaky mobile networks); malformed payloads stay at **ERROR**.

## Trade-offs

- Body capture is bounded at **256 KiB cached / 16 KiB logged** to keep heap and log lines sane. Happy to raise these or make them configurable if fuller payloads are wanted for investigation.

## Testing

- `./gradlew :chronicle-server:compileKotlin` — green.